### PR TITLE
Basic types for TX-2 registers, addresses, instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/target
+Cargo.lock
+*~

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,8 @@
+[workspace]
+
+members = [
+	# base includes a representation for instructions (which could
+	# be shared for example between the emulator and a
+	# cross-assembler).
+	"base",
+]

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2021 The TX-2 Simulator Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/base/Cargo.toml
+++ b/base/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "base"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/base/src/instruction/format.rs
+++ b/base/src/instruction/format.rs
@@ -1,0 +1,490 @@
+/// Human-oriented formatting for instructions (or parts of instructions).
+use std::fmt::{self, Display, Formatter, Octal};
+use std::error::Error;
+
+use crate::prelude::*;
+use crate::instruction::{
+    Quarter,
+    BitSelector,
+    DisassemblyFailure,
+    index_address_to_bit_selection,
+    Inst,
+    Opcode,
+    OperandAddress,
+    SymbolicInstruction,
+};
+
+/// Render the quarter ("q") part of the bit selector ("q.b").
+impl Display for Quarter {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+	f.write_str(match self {
+	    Quarter::Q1 => "1",
+	    Quarter::Q2 => "2",
+	    Quarter::Q3 => "3",
+	    Quarter::Q4 => "4",
+	})
+    }
+}
+
+/// Render the bit selector in the form q.b.  Unfortunately the TX2
+/// documentation is inconsistent in how the bit number is formatted.
+/// Page 3-34 of the User Handbook clearly says "Bit Numbers are
+/// interpreted asd Decimal".  However, the plugboard listing (page
+/// 5-27 of the same document) disassembles the instruction 301712
+/// 377744 as "³⁰SKN₄.₁₂ 377744" so here the bit number is given in
+/// octal.  We adopt the decimal convention since it is in wider use
+/// in the documentation.
+impl Display for BitSelector {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+	write!(f, "{}.{}", self.quarter, self.bitpos)
+    }
+}
+
+/// Convert an opcode to its text representation.
+///
+/// The primary (i.e. not supernumerary) opcode mnemonic is used,
+/// because the configuration value which would identify a
+/// supernumerary opcode is not passed to the `fmt` method of the
+/// `Display` trait.
+impl Display for Opcode {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+        use Opcode::*;
+        f.write_str(match self {
+            Ios => "IOS",
+            Jmp => "JMP",
+            Jpx => "JPX",
+            Jnx => "JNX",
+            Aux => "AUX",
+            Rsx => "RSX",
+            Skx => "SKX",
+            Exx => "EXX",
+            Adx => "ADX",
+            Dpx => "DPX",
+            Skm => "SKM",
+            Lde => "LDE",
+            Spf => "SPF",
+            Spg => "SPG",
+            Lda => "LDA",
+            Ldb => "LDB",
+            Ldc => "LDC",
+            Ldd => "LDD",
+            Ste => "STE",
+            Flf => "FLF",
+            Flg => "FLG",
+            Sta => "STA",
+            Stb => "STB",
+            Stc => "STC",
+            Std => "STD",
+            Ite => "ITE",
+            Ita => "ITA",
+            Una => "UNA",
+            Sed => "SED",
+            Jov => "JOV",
+            Jpa => "JPA",
+            Jna => "JNA",
+            Exa => "EXA",
+            Ins => "INS",
+            Com => "COM",
+            Tsd => "TSD",
+            Cya => "CYA",
+            Cyb => "CYB",
+            Cab => "CAB",
+            Noa => "NOA",
+            Dsa => "DSA",
+            Nab => "NAB",
+            Add => "ADD",
+            Sca => "SCA",
+            Scb => "SCB",
+            Sab => "SAB",
+            Tly => "TLY",
+            Div => "DIV",
+            Mul => "MUL",
+            Sub => "SUB",
+        })
+    }
+}
+
+/// Format an operand address in octal.
+///
+/// Deferred addresses are formatted in square brackets.  TX-2
+/// documentation seems variously to represent deferred addressing
+/// with `[...]` or `*`.  We use `[...]`.
+impl Octal for OperandAddress {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+        match self {
+            OperandAddress::Direct(addr) => {
+                write!(f, "{:o}", addr)
+            }
+            OperandAddress::Deferred(addr) => {
+                write!(f, "[{:o}]", addr)
+            }
+        }
+    }
+}
+
+impl Display for DisassemblyFailure {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+        let opcode = match self {
+            DisassemblyFailure::InvalidOpcode(n) => {
+                f.write_str("invalid opcode")?;
+                n
+            }
+            DisassemblyFailure::UnimplementedOpcode(n) => {
+                f.write_str("unimplemented opcode")?;
+                n
+            }
+        };
+        write!(f, " {:03o}", opcode)
+    }
+}
+
+fn superscript_digit(regular_digit: char) -> char {
+    match regular_digit {
+        '0' => '\u{2070}',
+        '1' => '\u{00B9}',
+        '2' => '\u{00B2}',
+        '3' => '\u{00B3}',
+        '4' => '\u{2074}',
+        '5' => '\u{2075}',
+        '6' => '\u{2076}',
+        '7' => '\u{2077}',
+        '8' => '\u{2078}',
+        '9' => '\u{2079}',
+        _ => {
+            panic!("non-digit '{}'", regular_digit);
+        }
+    }
+}
+
+fn octal_superscript_u8(n: u8) -> String {
+    format!("{:o}", n).chars().map(superscript_digit).collect()
+}
+
+#[derive(Debug, Clone, Copy)]
+struct NoSubscriptKnown(char);
+
+impl Display for NoSubscriptKnown {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+	write!(f, "bug: no subscript mapping is yet implemented for '{}'", self.0)
+    }
+}
+
+impl Error for NoSubscriptKnown {}
+
+fn subscript_char(ch: char) -> Result<char, NoSubscriptKnown> {
+    match ch {
+        '0' => Ok('\u{2080}'),	// ₀
+        '1' => Ok('\u{2081}'),	// ₁
+        '2' => Ok('\u{2082}'),	// ₂
+        '3' => Ok('\u{2083}'),	// ₃
+        '4' => Ok('\u{2084}'),	// ₄
+        '5' => Ok('\u{2085}'),	// ₅
+        '6' => Ok('\u{2086}'),	// ₆
+        '7' => Ok('\u{2087}'),	// ₇
+        '8' => Ok('\u{2088}'),	// ₈
+        '9' => Ok('\u{2089}'),	// ₉
+	'-' => Ok('\u{208B}'),	// ₋
+	'.' => Ok('.'),		// there appears to be no subscript version
+        _ =>  Err(NoSubscriptKnown(ch)),
+    }
+}
+
+fn subscript(s: &str) -> Result<String, NoSubscriptKnown> {
+    s.chars().map(subscript_char).collect()
+}
+
+
+fn octal_subscript_number(n: u8) -> String {
+    subscript(&format!("{:o}", n)).unwrap()
+}
+
+fn write_opcode(op: Opcode, cfg: Unsigned5Bit, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+    // Where there is a supernumerary mnemonic, prefer it.
+    // This list is taken from table 7-3 in the Users
+    // Handbook.
+    let cfg = u8::from(cfg);
+    match op {
+	Opcode::Jmp => f.write_str(match cfg {
+	    0o00 => "JMP",
+	    0o01 => "BRC",
+	    0o02 => "JPS",
+	    0o03 => "BRS",
+	    0o14 => "JPQ",
+	    0o15 => "BPQ",
+	    0o16 => "JES",
+	    0o20 => "JPD",
+	    0o21 => "JMP",
+	    0o22 => "JDS",
+	    0o23 => "BDS",
+	    _ => "JMP",
+	}),
+	Opcode::Skx => f.write_str(match cfg {
+	    0o00 => "REX",
+	    0o02 => "INX",
+	    0o03 => "DEX",
+	    0o04 => "SXD",
+	    0o06 => "SXL",
+	    0o07 => "SXG",
+	    0o10 => "RXF",
+	    0o20 => "RXD",
+	    0o30 => "RFD",
+	    _ => "SKX",
+	}),
+	Opcode::Skm => f.write_str(match cfg {
+	    0o00 => "SKM",
+	    0o01 => "MKC",
+	    0o02 => "MKZ",
+	    0o03 => "MKN",
+	    0o10 => "SKU",
+	    0o11 => "SUC",
+	    0o12 => "SUZ",
+	    0o13 => "SUN",
+	    0o20 => "SKZ",
+	    0o21 => "SZC",
+	    0o22 => "SZZ",
+	    0o23 => "SZN",
+	    0o30 => "SKN",
+	    0o31 => "SNC",
+	    0o32 => "SNZ",
+	    0o33 => "SNN",
+	    0o04 => "CYR",
+	    0o05 => "MCR",
+	    0o06 => "MZR",
+	    0o07 => "MNR",
+	    0o34 => "SNR",
+	    0o24 => "SZR",
+	    0o14 => "SUR",
+	    _ => "SKM",
+	}),
+	_ => write!(f, "{}", op)
+    }
+}
+
+impl Display for SymbolicInstruction {
+    /// Convert a `SymbolicInstruction` to text (Unicode) form.
+    ///
+    /// We use supernumerary opcode mnemonics where one is suitable
+    /// (though we keep the original configuration value).
+    /// Configuration values are rendered as superscripts.  Index
+    /// addresses are rendered as subscripts and operand addresses as
+    /// normal digits.  These match the conventions used in the TX-2
+    /// User Handbook.
+    ///
+    /// The User Handbook indicates that the hold bit should be
+    /// represented as _h_ (lower-case "H") when 1 and as _h_ with
+    /// overbar when 0.  We diverge from this usage for consistency
+    /// with the M4 listing of the Sketchpad code, which uses a
+    /// leading colon to indicate _hold_.  However, since I wasn't
+    /// able to find a negative override (setting _hold_ to zero) in
+    /// the Sketchpad code, we use &#x0127; (a Unicode lower-case h
+    /// with stroke) to signal that.  When the defer bit takes the
+    /// value which is the default for the current instruction,
+    /// nothing (neither "h" nor "&#x0127;") is printed.
+    ///
+    /// The representation of instructions may change over time as we
+    /// discover archival material containing program listings.  The
+    /// idea is to generally be consistent with the materials we have
+    /// available.
+    ///
+    /// Instructions such as SKM should show the index address as a
+    /// bit selector, but this may not yet happen in all the cases we
+    /// would want it.  This will change over time as we implement
+    /// more of the instruction opcodes in the emulator.
+    ///
+    /// Some addresses (arithmetic unit registers for example) are
+    /// "well-known" but we do not currently display these in symbolic
+    /// form.
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+	// This implementation of Display is incomplete because, for
+	// example there are some instructions for which the index
+	// value is rendered as X.Y (I believe these are the
+	// bit-manipulation instructions).  The I/O instructions also
+	// have special cases.
+	//
+	// We also don't render "special" addresses, such as the
+	// addresses of actual registers, in symbolic form.
+        match (self.opcode().hold_is_implicit(), self.is_held()) {
+            (true, false) => {
+                // I didn't find any examples of this (a programmer
+                // override to make a normally-held opcode actually
+                // not held) in the documentation so far.
+                //
+                // We will use the notation given in section 6-2.1
+                // ("Instruction Words") of the User Handbook.
+                f.write_str("\u{0127} ")?; // lower-case h with stroke
+            }
+            (false, true) => {
+                f.write_str(": ")?;
+            }
+            _ => {
+                // This is the default, so it needs no annotation.
+            }
+        }
+        if !self.configuration().is_zero() {
+            let cf: u8 = self.configuration().into();
+            f.write_str(&octal_superscript_u8(cf))?;
+        }
+	write_opcode(self.opcode(), self.configuration(), f)?;
+	let j = self.index_address();
+	match self.opcode() {
+	    Opcode::Skm => {
+		// The index address field in SKM instructions
+		// identify a bit in the operand to operate on, and
+		// are shown in the form "q.b".  The "q" identifies
+		// the quarter and the "b" the bit.
+		let selector: BitSelector = index_address_to_bit_selection(j);
+		let rendering: String = subscript(&selector.to_string()).unwrap();
+		f.write_str(&rendering)?;
+	    }
+	    _ => {
+		if j != 0 {
+		    f.write_str(&octal_subscript_number(u8::from(j)))?;
+		}
+	    }
+	}
+        write!(f, " {:>08o}", self.operand_address()) // includes [] if needed.
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config_value(n: u8) -> Unsigned5Bit {
+        Unsigned5Bit::try_from(n).expect("valid test data")
+    }
+
+    fn addr(a: u32) -> Address {
+        Address::from(Unsigned18Bit::try_from(a).expect("valid test data"))
+    }
+
+    #[test]
+    fn test_octal_superscript_u8() {
+        assert_eq!(&octal_superscript_u8(0), "\u{2070}", "0 decimal is 0 octal");
+        assert_eq!(&octal_superscript_u8(1), "\u{00B9}", "1 decimal is 1 octal");
+        assert_eq!(
+            &octal_superscript_u8(4),
+            "\u{02074}",
+            "4 decimal is 4 octal"
+        );
+        assert_eq!(
+            &octal_superscript_u8(11),
+            "\u{00B9}\u{00B3}",
+            "11 decimal is 13 octal"
+        );
+        assert_eq!(
+            &octal_superscript_u8(255),
+            "\u{00B3}\u{2077}\u{2077}",
+            "255 decimal is 377 octal"
+        );
+    }
+
+    #[test]
+    fn test_display_jmp() {
+        let sinst = SymbolicInstruction {
+            operand_address: OperandAddress::Direct(Address::from(
+                Unsigned18Bit::try_from(0o0377750).expect("valid test data"),
+            )),
+            index: Unsigned6Bit::ZERO,
+            opcode: Opcode::Jmp,
+            configuration: Unsigned5Bit::ZERO,
+            held: false,
+        };
+        assert_eq!(&sinst.to_string(), "JMP 377750");
+    }
+
+    #[test]
+    fn test_display_jpx_sutherland() {
+        // Example from the plotter service routine from Ivan Sutherland's
+        // SKETCHPAD, as held by the Computer History museum, PDF file
+        // 102726903-05-02-acc.pdf page 124 (hand-written page number
+        // 274).
+        //
+        // -1 JPX $ UNITS OFF1        76 06 34 200 156
+        //
+        // The $ there is a placeholder (just in this comment) for a blob
+        // on the scanned page that I simply can't read.  The assembled
+        // word on the right-hand side is easier to read, but the value
+        // there (34 octal) doesn't seem to correspond very well with what
+        // looks like a single digit index value.
+        //
+        // Hold is used in conjunction with the JPX opcode in order to
+        // prevent DISMISS (see page 3-26 of the User Guide which
+        // describes JPX).  Hence the -1 seems reasonable, though in
+        // any case M4 automatically puts a hold on JPX (as described
+        // on page 3-27 of the user guide).
+        //
+        // The TSX-2 has a front-panel button "Hold on LSPB" which
+        // makes the system behave as if the hold bit were set on all
+        // instructions; see User Guide, page 5-17.
+        let sinst = SymbolicInstruction {
+            operand_address: OperandAddress::Direct(addr(0o0200156_u32)),
+            index: Unsigned6Bit::try_from(0o34_u8).unwrap(),
+            opcode: Opcode::Jpx,
+            configuration: config_value(0o36), // 036 octal = 30 decimal = 0b11110
+            held: true,
+        };
+        assert_eq!(&sinst.to_string(), "³⁶JPX₃₄ 200156");
+    }
+
+    #[test]
+    fn test_display_jpx_progex() {
+        // These cases are taken from the programming examples
+        // document (memo 6M-5780, July 23, 1958).
+
+        // Example from Program I, address 377 765, instruction word 36 06 01 377 751.
+        let sinst1 = SymbolicInstruction {
+            operand_address: OperandAddress::Direct(addr(0o0377751)),
+            index: Unsigned6Bit::ONE,
+            opcode: Opcode::Jpx,
+            // 036 = 30 decimal = 0b11110, which is one's complement -1.
+            configuration: config_value(0o36),
+
+            // In the example program, we see the octal equivalent of
+            // the instruction, and the top bit is clearly not set, so
+            // instruction is not held.
+            held: false,
+        };
+        // In the Program I listing, there is no annotation indicating
+        // that the instruction is not held.  This memo is from 1958.
+        // Perhaps the conventions changed between then and the date
+        // of the User Handbook (1963).
+        //
+        // The actual example gives a configuration value of -1, but
+        // we have to choose a single way to render config values
+        // (i.e. choose one of -1 or 36 for bit pattern 0b11110).
+        // Compare for example test_display_rsx(), which points to an
+        // example where the configuration value is formatted the
+        // other way.
+        assert_eq!(&sinst1.to_string(), "ħ ³⁶JPX₁ 377751");
+
+        // Example from Program II ("Inchworm"), address 15, instruction word not stated,
+        let sinst2 = SymbolicInstruction {
+            operand_address: OperandAddress::Direct(addr(0o0377752)),
+            index: Unsigned6Bit::try_from(3_u8).unwrap(),
+            opcode: Opcode::Jpx,
+            // In the Program II example, the configuration value is
+            // given as -7.  We're using octal 30 and believe that is
+            // equivalent.
+            configuration: Unsigned5Bit::try_from(0o30_u8).expect("valid test data"),
+            held: false,
+        };
+        // ħ here for the same reason as sinst1 disassembled above.
+        assert_eq!(&sinst2.to_string(), "ħ ³⁰JPX₃ 377752");
+    }
+
+    #[test]
+    fn test_display_rsx() {
+        // Example from Program II ("Inchworm"), address 377 755,
+        // instruction word 74 11 71 377 763.  Note the leading colon,
+        // indicating the hold bit.
+        let sinst = SymbolicInstruction {
+            operand_address: OperandAddress::Direct(addr(0o377762)),
+            index: Unsigned6Bit::try_from(0o71_u8).unwrap(),
+            opcode: Opcode::Rsx,
+            configuration: config_value(0o34),
+            held: true, // this is signaled by the colon.
+        };
+        assert_eq!(&sinst.to_string(), ": ³⁴RSX₇₁ 377762"); // the ':' indicates `held`
+    }
+}

--- a/base/src/instruction/mod.rs
+++ b/base/src/instruction/mod.rs
@@ -1,0 +1,612 @@
+//! Binary and symbolic representations of TX-2 instructions.
+//!
+//! A TX-2 instruction occupies 36 bits.  The 36 bits look like this
+//! (least significant bit on the right, bits numbered 0 to 35 in
+//! decimal):
+//!
+//! |Hold |Configuration| Opcode|Index  |Defer|Operand Memory Address|
+//! |-----|-------------|-------|-------|-----|----------------------|
+//! |1 bit|  5 bits     |6 bits |6 bits |1 bit|      17 bits         |
+//! |(35) | (30-34)     |(24-29)|(18-23)|     |       (0-16)         |
+//!
+//! This diagram is taken from section 6-2.1 "INSTRUCTION WORDS" of the
+//! TX-2 Users Handbook (page 6-4, being the 157th page of my PDF file).
+//!
+//! There is a similar diagram in Fig. 5 (p. 11) of "A Functional
+//! Description of the Lincoln TX-2 Computer" by John M. Frankovitch
+//! and H. Philip Peterson, but that is older and, I believe,
+//! inaccurate in the width of the configuration field for example.
+//! Section 6-2.1 of the User Handbook confirms that the configuration
+//! "syllable" is 5 bits.
+//!
+//! Table 7-2 in the user guide defines values of `cf` for the range 0
+//! to 037 inclusive in terms of the standard contents that they fetch
+//! from the F-memory.
+//!
+//! In the programming examples (6M-5780, page 6) we have
+//!
+//! `34 21 00 377,751     34SPF 377751`
+//!
+//! Here, the operand memory address is 0377751.  The index is 00.
+//! The opcode is `SPF`, octal 21.  The top 6 bits are 034, or 11100
+//! binary.  The user guide states that `SPF` is not configurable, so
+//! presumably the configuration field simply specifies the address in
+//! F-memory that we will write to.
+//!
+//! Later in the same page we have
+//!
+//! `74 11 71 377,762    34RSX71  377,762`
+//!
+//! RSX is opcode 11.  Hence the top 6 bits are 074 = 111100 binary,
+//! Of those only 034=11100 binary seem to be configuration code.  But
+//! the hold bit seems to be set without this being indicated in the
+//! symbolic form of the instruction.
+
+use std::fmt::{self, Debug, Formatter};
+
+use crate::prelude::*;
+use crate::subword;
+
+mod format;
+
+
+/// `Quarter` describes which quarter of a word an SKM instruction
+/// will operate on.  See the [`index_address_to_bit_selection`]
+/// function.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Quarter {
+    Q1 = 0,
+    Q2 = 1,
+    Q3 = 2,
+    Q4 = 3,
+}
+
+/// Convert the `Quarter` enumeration value into the position of that
+/// quarter (counting from the least-significant end of the 36-bit
+/// word).
+impl From<Quarter> for u8 {
+    fn from(q: Quarter) -> u8 {
+	match q {
+	    Quarter::Q1 => 0,
+	    Quarter::Q2 => 1,
+	    Quarter::Q3 => 2,
+	    Quarter::Q4 => 3,
+	}
+    }
+}
+
+/// `BitSelector` is primarily for use with the SKM instruction which
+/// can access bits 1-9 of quarters, plus the meta and parity bits (of
+/// the full word).  Hence the wider range.  See the
+/// [`index_address_to_bit_selection`] function.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct BitSelector {
+    pub quarter: Quarter,
+    /// `bitpos` values 1 to 9 inclusive are normal bit positions in a
+    /// quarter.  0 is a valid value but not a valid bit (so a default
+    /// will be used when SKM tests bit 0).  10 is the meta bit.  11
+    /// is the parity bit stored in memory.  12 is the parity value
+    /// computed from the bits stored in memory.
+    pub bitpos: u8,	// takes values 0..=12.
+}
+
+/// Convert the index address field of an SKM instruction into a
+/// `BitSelector` struct describing which bit we will operate on.
+pub fn index_address_to_bit_selection(index_address: Unsigned6Bit) -> BitSelector {
+    let j: u8 = u8::from(index_address);
+    BitSelector {
+	quarter: match (j >> 4) & 0b11 {
+	    0 => Quarter::Q4,
+	    1 => Quarter::Q1,
+	    2 => Quarter::Q2,
+	    3 => Quarter::Q3,
+	    _ => unreachable!(),
+	},
+	bitpos: j & 0b1111_u8,
+    }
+}
+
+/// A TX-2 Instruction.
+#[derive(Clone, Copy)]
+pub struct Instruction(Unsigned36Bit);
+
+impl Instruction {
+    /// Returns an unspecified invalid instruction.
+    pub fn invalid() -> Instruction {
+        Instruction(Unsigned36Bit::ZERO)
+    }
+}
+
+impl From<Unsigned36Bit> for Instruction {
+    fn from(w: Unsigned36Bit) -> Instruction {
+        Instruction(w)
+    }
+}
+
+impl From<Instruction> for Unsigned36Bit {
+    fn from(inst: Instruction) -> Unsigned36Bit {
+	inst.0
+    }
+}
+
+impl Debug for Instruction {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+        let lhs = match SymbolicInstruction::try_from(self) {
+            Ok(sym) => format!("{}", sym),
+            Err(e) => format!("(invalid instruction: {})", e),
+        };
+        write!(f, "{:<40} {}", lhs, self.0)
+    }
+}
+
+/// The `Inst` trait provides a way to extract the various fields
+/// within an instruction.
+pub trait Inst {
+    /// Obtain the value of the "hold" bit.
+    fn is_held(&self) -> bool;
+
+    /// Fetch the configuration field of the instruction.  This is
+    /// used as an index to fetch a system configuration from the
+    /// F-memory.  Table 7-2 in the TX-2 User Handbook explains what
+    /// data exists in the F-memory in the standard configuration.
+    ///
+    /// The meaning of the values fetched from the F-memory (and thus,
+    /// the significance of the configuration values of an
+    /// instruction) is explained in Volume 2 (pages 12-19) of the
+    /// Technical manual.  Some instructions (JMP, for example) use
+    /// this field differently.
+    fn configuration(&self) -> Unsigned5Bit;
+
+    /// indexation is actually a signed operation (see the [`IndexBy`]
+    /// trait) but index addresses are shown as positive numbers
+    /// (e.g. 77) in assembler source code.
+    fn index_address(&self) -> Unsigned6Bit;
+
+    /// The opcode of the instruction.
+    fn opcode_number(&self) -> u8;
+
+    /// The value of the defer bit from the operand address field.
+    fn is_deferred_addressing(&self) -> bool;
+
+    /// The operand address field (including the defer bit)
+    fn operand_address(&self) -> OperandAddress;
+
+    /// Fetches the operand address with the defer bit (if set) in bit
+    /// position 17.
+    fn operand_address_and_defer_bit(&self) -> Unsigned18Bit;
+}
+
+impl Inst for Instruction {
+    fn is_held(&self) -> bool {
+        const HOLD_BIT: u64 = 1_u64 << 35;
+        !(self.0 & HOLD_BIT).is_zero()
+    }
+
+    fn configuration(&self) -> Unsigned5Bit {
+        let val: u8 = u8::try_from((self.0 >> 30) & 31_u64).unwrap();
+        Unsigned5Bit::try_from(val).unwrap()
+    }
+
+    fn opcode_number(&self) -> u8 {
+        u8::try_from((self.0 >> 24) & 63_u64).unwrap()
+    }
+
+    fn index_address(&self) -> Unsigned6Bit {
+        Unsigned6Bit::try_from((self.0 >> 18) & 63_u64).unwrap()
+    }
+
+    fn is_deferred_addressing(&self) -> bool {
+        self.0 & 0o400_000_u64 != 0
+    }
+
+    fn operand_address(&self) -> OperandAddress {
+        const PHYSICAL_ADDRESS_BITS: u32 = 0o377_777;
+        let physical_address = Address::from(subword::right_half(self.0) & PHYSICAL_ADDRESS_BITS);
+        if self.0 & 0o400_000 != 0 {
+            OperandAddress::Deferred(physical_address)
+        } else {
+            OperandAddress::Direct(physical_address)
+        }
+    }
+
+    fn operand_address_and_defer_bit(&self) -> Unsigned18Bit {
+        let bits: u32 = u32::try_from(self.0 & 0o777_777).unwrap();
+        Unsigned18Bit::try_from(bits).unwrap() // range already checked above.
+    }
+}
+
+/// `Opcode` enumerates all the valid TX-2 opcodes.  These values are
+/// taken from the User Handbook.  Volume 3 of the Technical Manual
+/// (page 1-5-3) describes opcodes 00, 01, 02, 03, 04 (mentioning bit
+/// 2.8 of N being in state 1), 13, 23, 33, 45, 50, 51, 52, 53, 63, 73
+/// as being undefined.
+///
+/// Different copies of the User Handbook differ in the description of
+/// opcodes 0o44 and 0o45.
+#[repr(u8)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum Opcode {
+    // opcode 1 is unused
+    // opcode 2 may be XEQ, but no documentation on this.
+    // opcode 3 is unused
+    Ios = 0o4, // see also Vol 3 page 16-05-07
+    Jmp = 0o5,
+    Jpx = 0o6,
+    Jnx = 0o7,
+    Aux = 0o10,
+    Rsx = 0o11,
+    Skx = 0o12,
+    // opcode 0o13 = 11 is undefined (unused).
+    Exx = 0o14,
+    Adx = 0o15,
+    Dpx = 0o16,
+    Skm = 0o17,
+    Lde = 0o20,
+    Spf = 0o21,
+    Spg = 0o22,
+    // opcode 0o23 = 19 is undefined (unused).
+    Lda = 0o24,
+    Ldb = 0o25,
+    Ldc = 0o26,
+    Ldd = 0o27,
+    Ste = 0o30,
+    Flf = 0o31,
+    Flg = 0o32,
+    // opcode 033 = 27 is unused.
+    Sta = 0o34,
+    Stb = 0o35,
+    Stc = 0o36,
+    Std = 0o37,
+    Ite = 0o40,
+    Ita = 0o41,
+    Una = 0o42,
+    Sed = 0o43,
+
+    /// I have two copies of the User Handbook and they differ in
+    /// their description of opcodes 0o44, 0o45.
+    ///
+    /// In the August 1963 copy, 0o44 is missing and 0045 is JOV.
+    ///
+    /// In the index of the October 1961 copy, 0o44 is JOV and 0o45 is
+    /// JZA (handwritten).  However, in this copy, page 3-32 (which
+    /// describes JPA, JNA, JOV) gives JOV as 0o45.  So I assume this
+    /// is just an error in the index.  This copy does not otherwise
+    /// describe a JZA opcode.
+    Jov = 0o45,
+
+    Jpa = 0o46,
+    Jna = 0o47,
+    // opcode 0o50 = 40 is undefined (unused).
+    // opcode 0o51 = 41 is undefined (unused).
+    // opcode 0o52 = 42 is undefined (unused).
+    // opcode 0o53 = 43 is undefined (unused).
+    Exa = 0o54,
+    Ins = 0o55,
+    Com = 0o56,
+    Tsd = 0o57,
+    Cya = 0o60,
+    Cyb = 0o61,
+    Cab = 0o62,
+    // opcode 0o63 = 51 is unused.
+    Noa = 0o64,
+    Dsa = 0o65,
+    Nab = 0o66,
+    Add = 0o67,
+    Sca = 0o70,
+    Scb = 0o71,
+    Sab = 0o72,
+    // opcode 0o71 = 59 is unused.
+    Tly = 0o74,
+    Div = 0o75,
+    Mul = 0o76,
+    Sub = 0o77,
+}
+
+impl Opcode {
+    pub fn number(&self) -> u8 {
+        *self as u8
+    }
+
+    pub fn hold_is_implicit(&self) -> bool {
+	matches!(self, Opcode::Lde | Opcode::Ite | Opcode::Jpx | Opcode::Jnx)
+    }
+}
+
+impl TryFrom<u8> for Opcode {
+    type Error = DisassemblyFailure;
+    fn try_from(opcode: u8) -> Result<Opcode, DisassemblyFailure> {
+        use Opcode::*;
+        match opcode {
+            // TODO: change these opcode values to octal.
+            0 | 1 => Err(DisassemblyFailure::InvalidOpcode(opcode)),
+            2 => {
+                // Maybe XEQ?
+                Err(DisassemblyFailure::UnimplementedOpcode(opcode))
+            }
+            3 => Err(DisassemblyFailure::InvalidOpcode(opcode)),
+            0o4 => Ok(Ios),
+            0o5 => Ok(Jmp),
+            0o6 => Ok(Jpx),
+            0o7 => Ok(Jnx),
+            0o10 => Ok(Aux),
+            0o11 => Ok(Rsx),
+            0o12 => Ok(Skx),
+            11 => Err(DisassemblyFailure::InvalidOpcode(opcode)),
+            12 => Ok(Exx),
+            13 => Ok(Adx),
+            14 => Ok(Dpx),
+            15 => Ok(Skm),
+            16 => Ok(Lde),
+            17 => Ok(Spf),
+            18 => Ok(Spg),
+            19 => Err(DisassemblyFailure::InvalidOpcode(opcode)),
+            20 => Ok(Lda),
+            21 => Ok(Ldb),
+            22 => Ok(Ldc),
+            23 => Ok(Ldd),
+            24 => Ok(Ste),
+            25 => Ok(Flf),
+            26 => Ok(Flg),
+            27 => Err(DisassemblyFailure::InvalidOpcode(opcode)),
+            28 => Ok(Sta),
+            29 => Ok(Stb),
+            30 => Ok(Stc),
+            31 => Ok(Std),
+            32 => Ok(Ite),
+            33 => Ok(Ita),
+            34 => Ok(Una),
+            35 => Ok(Sed),
+            // 36 is unused
+            36 => Err(DisassemblyFailure::InvalidOpcode(opcode)),
+            37 => Ok(Jov),
+            38 => Ok(Jpa),
+            39 => Ok(Jna),
+            40..=43 => Err(DisassemblyFailure::InvalidOpcode(opcode)),
+            44 => Ok(Exa),
+            45 => Ok(Ins),
+            46 => Ok(Com),
+            47 => Ok(Tsd),
+            48 => Ok(Cya),
+            49 => Ok(Cyb),
+            50 => Ok(Cab),
+            51 => Err(DisassemblyFailure::InvalidOpcode(opcode)),
+            52 => Ok(Noa),
+            53 => Ok(Dsa),
+            54 => Ok(Nab),
+            55 => Ok(Add),
+            56 => Ok(Sca),
+            57 => Ok(Scb),
+            58 => Ok(Sab),
+            59 => Err(DisassemblyFailure::InvalidOpcode(opcode)),
+            60 => Ok(Tly),
+            61 => Ok(Div),
+            62 => Ok(Mul),
+            63 => Ok(Sub),
+            _ => Err(DisassemblyFailure::InvalidOpcode(opcode)),
+        }
+    }
+}
+
+/// OperandAddress represents the least-significant 18 bits of an
+/// instruction word.  By using an enumeration for this we make it
+/// harder to accidentally mix up operand addresses (which might have
+/// a defer bit) and physical addresses (which only have 17 useful
+/// bits, since the highest physical memory address is 377 777).
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum OperandAddress {
+    Direct(Address),
+    Deferred(Address),
+}
+
+/// A TX-2 instruction broken down into its component fields.
+#[derive(Debug, PartialEq, Eq)]
+pub struct SymbolicInstruction {
+    operand_address: OperandAddress,
+    index: Unsigned6Bit,
+    opcode: Opcode,
+    configuration: Unsigned5Bit,
+    held: bool,
+}
+
+impl SymbolicInstruction {
+    pub fn opcode(&self) -> Opcode {
+        self.opcode
+    }
+}
+
+impl Inst for SymbolicInstruction {
+    fn is_held(&self) -> bool {
+        self.held
+    }
+
+    fn configuration(&self) -> Unsigned5Bit {
+        self.configuration
+    }
+
+    fn index_address(&self) -> Unsigned6Bit {
+        self.index
+    }
+
+    fn opcode_number(&self) -> u8 {
+        self.opcode.number()
+    }
+
+    fn is_deferred_addressing(&self) -> bool {
+        matches!(self.operand_address, OperandAddress::Deferred(_))
+    }
+
+    fn operand_address(&self) -> OperandAddress {
+        self.operand_address
+    }
+
+    fn operand_address_and_defer_bit(&self) -> Unsigned18Bit {
+	const ADDRESS_DEFER_BIT: u32 = 0o400_000;
+        match self.operand_address {
+            OperandAddress::Deferred(addr) => {
+                let defer_bit = Unsigned18Bit::try_from(ADDRESS_DEFER_BIT).unwrap();
+                Unsigned18Bit::from(addr) | defer_bit
+            }
+            OperandAddress::Direct(addr) => Unsigned18Bit::from(addr),
+        }
+    }
+}
+
+impl From<&SymbolicInstruction> for Instruction {
+    fn from(s: &SymbolicInstruction) -> Instruction {
+        let hold_bit: u64 = if s.is_held() { 1 << 35 } else { 0 };
+        let cf_bits: u64 = (u64::from(s.configuration()) & 31_u64) << 30;
+        let op_bits: u64 = (u64::from(s.opcode_number()) & 63) << 24;
+        let address_and_defer_bits: u64 = s.operand_address_and_defer_bit().into();
+        let val: u64 = hold_bit | cf_bits | op_bits | address_and_defer_bits;
+        Instruction(Unsigned36Bit::try_from(val).unwrap())
+    }
+}
+
+/// Signals that an [`Instruction`] could not be converted to a
+/// [`SymbolicInstruction`].
+#[derive(PartialEq, Eq)]
+pub enum DisassemblyFailure {
+    /// The opcode field of the instruction word does not correspond
+    /// to a known opcode.
+    InvalidOpcode(u8),
+
+    /// The opcode field of the instruction word corresponds to an
+    /// operation we know nothing about.  This enumerator shouldn't be
+    /// considered stable; we might remove it entirely.  Currently only
+    /// opcode 2 yields this result (corresponding to "XEQ?"
+    /// hand-written on a copy of the User Handbook).
+    UnimplementedOpcode(u8),
+}
+
+impl Debug for DisassemblyFailure {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+        let opcode = match self {
+            DisassemblyFailure::InvalidOpcode(n) => {
+                f.write_str("InvalidOpcode")?;
+                n
+            }
+            DisassemblyFailure::UnimplementedOpcode(n) => {
+                f.write_str("UnimplementedOpcode")?;
+                n
+            }
+        };
+        write!(f, "(0{:o})", opcode)
+    }
+}
+
+impl TryFrom<&Instruction> for SymbolicInstruction {
+    type Error = DisassemblyFailure;
+    fn try_from(inst: &Instruction) -> Result<SymbolicInstruction, DisassemblyFailure> {
+        Ok(SymbolicInstruction {
+            operand_address: inst.operand_address(),
+            index: inst.index_address(),
+            opcode: Opcode::try_from(inst.opcode_number())?,
+            configuration: inst.configuration(),
+            held: inst.is_held(),
+        })
+    }
+}
+
+// disassemble_word is intended to be used in the emulator's UI to
+// show what the program counter is pointing at, and to show the next
+// instruction to be emulated etc.  Since this is not yet implemented,
+// right now the only callers are unit tests.
+#[cfg(test)]
+pub fn disassemble_word(w: Unsigned36Bit) -> Result<SymbolicInstruction, DisassemblyFailure> {
+    let inst: Instruction = Instruction(w);
+    dbg!(inst.operand_address());
+    SymbolicInstruction::try_from(&inst)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config_value(n: u8) -> Unsigned5Bit {
+        Unsigned5Bit::try_from(n).expect("valid test data")
+    }
+
+    fn addr(a: u32) -> Address {
+        Address::from(Unsigned18Bit::try_from(a).expect("valid test data"))
+    }
+
+    #[test]
+    fn test_instruction_jmp() {
+        let inst = Instruction(Unsigned36Bit::from(0o0500377750_u32));
+        assert_eq!(
+            inst.operand_address(),
+            OperandAddress::Direct(addr(0o0377750_u32)),
+            "wrong address"
+        );
+        assert_eq!(inst.is_deferred_addressing(), false, "wrong dismis");
+        assert_eq!(inst.index_address(), 0, "wrong index");
+        assert_eq!(inst.opcode_number(), 5, "wrong opcode");
+        assert!(inst.configuration().is_zero(), "wrong cf");
+        assert_eq!(inst.is_held(), false, "wrong held");
+    }
+
+    #[test]
+    fn test_instruction_held() {
+        assert!(!Instruction(Unsigned36Bit::ZERO).is_held());
+        assert!(Instruction(
+            Unsigned36Bit::try_from(1_u64 << 35).expect("test data should be in-range")
+        )
+        .is_held());
+    }
+
+    #[test]
+    fn test_opcode_value_round_trip() {
+        for opcode_number in 0..u8::MAX {
+            if let Ok(opcode) = Opcode::try_from(opcode_number) {
+                assert_eq!(opcode_number, opcode.number());
+            }
+        }
+    }
+
+    #[test]
+    fn test_disassemble_jmp() {
+        assert_eq!(
+            disassemble_word(
+                Unsigned36Bit::try_from(0o000_500_377_750).expect("test data should be in range")
+            ),
+            Ok(SymbolicInstruction {
+                operand_address: OperandAddress::Direct(addr(0o0377750)),
+                index: Unsigned6Bit::ZERO,
+                opcode: Opcode::Jmp,
+                configuration: config_value(0),
+                held: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_disassemble_jpx() {
+        assert_eq!(
+            disassemble_word(
+                Unsigned36Bit::try_from(0o700_603_377_752_u64)
+                    .expect("test data should be in range")
+            ),
+            Ok(SymbolicInstruction {
+                operand_address: OperandAddress::Direct(addr(0o0377752)),
+                index: Unsigned6Bit::try_from(3_u8).unwrap(),
+                opcode: Opcode::Jpx,
+                configuration: config_value(24), // -7
+                held: true,
+            })
+        );
+
+        assert_eq!(
+            disassemble_word(
+                Unsigned36Bit::try_from(0o360_601_377_751_u64)
+                    .expect("test data should be in range")
+            ),
+            Ok(SymbolicInstruction {
+                operand_address: OperandAddress::Direct(addr(0o0377751)),
+                index: Unsigned6Bit::ONE,
+                opcode: Opcode::Jpx,
+                configuration: config_value(30),
+                held: false,
+            })
+        );
+    }
+}

--- a/base/src/lib.rs
+++ b/base/src/lib.rs
@@ -1,0 +1,12 @@
+//! The `base` crate defines the TX2-related things which are useful
+//! in both a simulator and other associated tools.  The idea is that
+//! if you want to write an assembler, it would depend on the base
+//! crate but would not need to depend on the simulator library
+//! itself.
+
+mod onescomplement;
+mod types;
+
+pub mod instruction;
+pub mod prelude;
+pub mod subword;

--- a/base/src/onescomplement/error.rs
+++ b/base/src/onescomplement/error.rs
@@ -1,0 +1,23 @@
+//! Basic error reporting.
+
+use std::error::Error;
+use std::fmt::{self, Debug, Display, Formatter};
+
+/// Represents a failure to convert to or from one of the signed or
+/// unsigned types defined in the base crate.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ConversionFailed {
+    TooLarge,
+    TooSmall,
+}
+
+impl Error for ConversionFailed {}
+
+impl Display for ConversionFailed {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+        match self {
+            ConversionFailed::TooLarge => f.write_str("value is too large"),
+            ConversionFailed::TooSmall => f.write_str("value is too small"),
+        }
+    }
+}

--- a/base/src/onescomplement/mod.rs
+++ b/base/src/onescomplement/mod.rs
@@ -1,0 +1,23 @@
+//! This module implements one's complement fixed-width signed types
+//! for use in emulating the TX-2, plus related unsigned types of the
+//! same width.
+
+pub mod error;
+pub mod signed;
+pub mod unsigned;
+
+/// The sign of a number.  Although in a one's-complement system all
+/// values have a sign, we treat zero specially in order to simplify
+/// working with native types and one's-complement types together.
+pub enum Sign {
+    Negative = -1, // <= -1
+    Zero = 0,      // +0 or -0
+    Positive = 1,  // >= +1
+}
+
+/// Trait common to both signed one's-complement types (defined in the
+/// [`signed`] module) and unsigned types (defined in the [`unsigned`]
+/// module).
+pub trait WordCommon {
+    fn signum(&self) -> Sign;
+}

--- a/base/src/onescomplement/signed/mod.rs
+++ b/base/src/onescomplement/signed/mod.rs
@@ -1,0 +1,499 @@
+use std::cmp::Ordering;
+use std::fmt::{self, Debug, Formatter, Octal};
+use std::hash::{Hash, Hasher};
+
+use super::error::ConversionFailed;
+use super::{Sign, WordCommon};
+use super::unsigned::*;
+
+#[cfg(test)]
+mod tests18;
+#[cfg(test)]
+mod tests36;
+#[cfg(test)]
+mod tests5;
+#[cfg(test)]
+mod tests9;
+
+// This macro implements conversions from native types to Unsigned*Bit
+// which are always possible (e.g. From<i8> for Signed9Bit).
+macro_rules! from_native_type_to_self {
+    ($SelfT:ty, $InnerT:ty, $SignedInnerT:ty, $($from:ty)*) => {
+	$(
+	    impl From<$from> for $SelfT {
+		fn from(n: $from) -> Self {
+		    let v: $SignedInnerT = n.into();
+		    Self {
+			bits: <$SelfT>::convert_to_ones_complement(v),
+		    }
+		}
+	    }
+	)*
+    }
+}
+
+macro_rules! try_from_native_type_to_self {
+    ($SelfT:ty, $InnerT:ty, $SignedInnerT:ty, $($from:ty)*) => {
+	$(
+	    impl TryFrom<$from> for $SelfT {
+		type Error = ConversionFailed;
+		fn try_from(n: $from) -> Result<$SelfT, ConversionFailed> {
+		    match n.try_into() {
+			Err(_) if n > 0 => Err(ConversionFailed::TooLarge),
+			Err(_) => Err(ConversionFailed::TooSmall),
+			Ok(signed_value) => {
+			    if signed_value > (Self::VALUE_BITS as $SignedInnerT) {
+				Err(ConversionFailed::TooLarge)
+			    } else if signed_value < -(Self::VALUE_BITS as $SignedInnerT) {
+				Err(ConversionFailed::TooSmall)
+			    } else {
+				Ok(Self {
+				    bits: <$SelfT>::convert_to_ones_complement(signed_value)
+				})
+			    }
+			}
+		    }
+		}
+	    }
+	)*
+    }
+}
+
+// This macro implements conversions from Unsigned*Bit to native types
+// which are always possible (e.g. From<Signed9Bit> for i16).
+macro_rules! from_self_to_native_type {
+    ($SelfT:ty, $InnerT:ty, $SignedInnerT:ty, $($to:ty)*) => {
+	$(
+	    impl From<$SelfT> for $to {
+		fn from(n: $SelfT) -> $to {
+		    if n.is_zero() {
+			0 as Self
+		    } else if n.is_negative() {
+			let inverted_bits = (!n.bits) & <$SelfT>::VALUE_BITS;
+			let absolute_value = inverted_bits as $SignedInnerT;
+			(-absolute_value) as Self
+		    } else {
+			n.bits as Self
+		    }
+		}
+	    }
+	)*
+    }
+}
+
+// This macro implements conversions from Unsigned*Bit to native types
+// which may not always be possible (e.g. From<Signed18Bit> for u16).
+macro_rules! try_from_self_to_native_type {
+    ($SelfT:ty, $InnerT:ty, $SignedInnerT:ty, $($to:ty)*) => {
+	$(
+	    impl TryFrom<$SelfT> for $to {
+		type Error = ConversionFailed;
+		fn try_from(n: $SelfT) -> Result<$to, ConversionFailed> {
+		    if n.is_zero() {
+			return Ok(0);
+		    }
+		    #[allow(unused_comparisons)]
+		    if n.is_negative() {
+			let inverted_bits: $InnerT = (!n.bits) & <$SelfT>::VALUE_BITS;
+			let absolute_value: $SignedInnerT = inverted_bits as $SignedInnerT;
+			<$to>::try_from(-absolute_value)
+			    .map_err(|_| ConversionFailed::TooSmall)
+		    } else {
+			<$to>::try_from(n.bits)
+			    .map_err(|_| ConversionFailed::TooLarge)
+		    }
+		}
+	    }
+	)*
+    }
+}
+
+macro_rules! signed_ones_complement_impl {
+    ($SelfT:ty, $BITS:expr, $InnerT:ty, $SignedInnerT:ty, $UnsignedPeerT:ty) => {
+        impl $SelfT {
+            const SIGN_BIT: $InnerT = 1 << ($BITS - 1);
+            const VALUE_BITS: $InnerT = Self::SIGN_BIT - 1;
+            const ALL_BITS: $InnerT = Self::SIGN_BIT | Self::VALUE_BITS;
+
+            pub const MAX: Self = Self {
+                bits: Self::VALUE_BITS,
+            };
+
+            pub const MIN: Self = Self {
+                bits: Self::SIGN_BIT,
+            };
+
+            pub const ZERO: Self = Self { bits: 0 };
+            pub const ONE: Self = Self { bits: 1 };
+
+            pub const fn is_zero(&self) -> bool {
+                self.bits == 0 || self.bits == Self::ALL_BITS
+            }
+
+	    pub const fn reinterpret_as_unsigned(&self) -> $UnsignedPeerT {
+		type T = $UnsignedPeerT;
+		T { bits: self.bits }
+	    }
+
+            pub const fn is_negative(&self) -> bool {
+                self.bits & Self::SIGN_BIT != 0 && !self.is_zero()
+            }
+
+            pub const fn is_positive(&self) -> bool {
+                self.bits & Self::SIGN_BIT == 0 || self.is_zero()
+            }
+
+            pub const fn convert_to_ones_complement(signed: $SignedInnerT) -> $InnerT {
+                if signed < 0 {
+                    let absolute: $InnerT = (-signed) as $InnerT;
+                    let bits: $InnerT = (!absolute) & Self::ALL_BITS;
+                    bits
+                } else {
+                    signed as $InnerT
+                }
+            }
+
+            pub fn checked_add(self, rhs: $SelfT) -> Option<$SelfT> {
+                let left = <$SignedInnerT>::from(self);
+                let right = <$SignedInnerT>::from(rhs);
+                match left.checked_add(right) {
+                    Some(result) => Self::try_from(result).ok(),
+                    None => None,
+                }
+            }
+
+            pub fn checked_sub(self, rhs: $SelfT) -> Option<$SelfT> {
+                let left = <$SignedInnerT>::from(self);
+                let right = <$SignedInnerT>::from(rhs);
+                match left.checked_sub(right) {
+                    Some(result) => Self::try_from(result).ok(),
+                    None => None,
+                }
+            }
+
+	    pub fn wrapping_add(self, rhs: $SelfT) -> $SelfT {
+                let left = <$SignedInnerT>::from(self);
+                let right = <$SignedInnerT>::from(rhs);
+		let (result, overflow) = left.overflowing_add(right);
+		if overflow {
+		    panic!("bug: $SignedInnerT is not wide enough to perform no-overflow arithmetic");
+		}
+		const MODULUS: $SignedInnerT = 1 << ($BITS - 1);
+		Self {
+		    bits: Self::convert_to_ones_complement(result % MODULUS),
+		}
+	    }
+
+	    pub fn wrapping_sub(self, rhs: $SelfT) -> $SelfT {
+                let left = <$SignedInnerT>::from(self);
+                let right = <$SignedInnerT>::from(rhs);
+		let (result, overflow) = left.overflowing_sub(right);
+		if overflow {
+		    panic!("bug: $SignedInnerT is not wide enough to perform no-overflow arithmetic");
+		}
+		const MODULUS: $SignedInnerT = 1 << ($BITS - 1);
+		Self {
+		    bits: Self::convert_to_ones_complement(result % MODULUS),
+		}
+	    }
+
+            pub const fn abs(self) -> Self {
+                if self.is_zero() {
+                    Self::ZERO
+                } else if self.is_negative() {
+                    Self {
+                        bits: (!self.bits) & Self::VALUE_BITS,
+                    }
+                } else {
+                    self
+                }
+            }
+
+            pub const fn overflowing_abs(self) -> (Self, bool) {
+                (self.abs(), false)
+            }
+        }
+
+        impl Default for $SelfT {
+            fn default() -> Self {
+                Self { bits: 0 }
+            }
+        }
+
+        impl Octal for $SelfT {
+            fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+                Octal::fmt(&self.bits, f)
+            }
+        }
+
+        impl Debug for $SelfT {
+            fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+                write!(f, concat!(stringify!($SelfT), "{{bits: {:#o}}}"), self.bits)
+            }
+        }
+
+        impl Hash for $SelfT {
+            fn hash<H>(&self, state: &mut H)
+            where
+                H: Hasher,
+            {
+                if self.is_zero() {
+                    // -0 should hash to the same value as +0.
+                    let instead: $InnerT = 0;
+                    instead.hash(state)
+                } else {
+                    self.bits.hash(state)
+                }
+            }
+        }
+
+        impl PartialEq for $SelfT {
+            fn eq(&self, other: &$SelfT) -> bool {
+                match self.cmp(other) {
+                    Ordering::Equal => true,
+                    _ => false,
+                }
+            }
+        }
+
+        impl PartialEq<$SignedInnerT> for $SelfT {
+            fn eq(&self, other: &$SignedInnerT) -> bool {
+                match self.partial_cmp(other) {
+                    Some(Ordering::Equal) => true,
+                    _ => false,
+                }
+            }
+        }
+
+        impl Eq for $SelfT {}
+
+        impl PartialOrd for $SelfT {
+            fn partial_cmp(&self, other: &$SelfT) -> Option<Ordering> {
+                Some(self.cmp(other))
+            }
+        }
+
+        impl PartialOrd<$SignedInnerT> for $SelfT {
+            fn partial_cmp(&self, other: &$SignedInnerT) -> Option<Ordering> {
+                let lhs = <$SignedInnerT>::from(*self);
+                Some(lhs.cmp(other))
+            }
+        }
+
+        impl Ord for $SelfT {
+            fn cmp(&self, other: &$SelfT) -> Ordering {
+                // We perform conversion here so that -0 == +0.
+                let lhs = <$SignedInnerT>::from(*self);
+                let rhs = <$SignedInnerT>::from(*other);
+                lhs.cmp(&rhs)
+            }
+        }
+
+        impl WordCommon for $SelfT {
+            fn signum(&self) -> Sign {
+                if self.is_zero() {
+                    Sign::Zero
+                } else if self.is_negative() {
+                    Sign::Negative
+                } else {
+                    Sign::Positive
+                }
+            }
+        }
+    };
+}
+
+////////////////////////////////////////////////////////////////////////
+// Signed5Bit
+////////////////////////////////////////////////////////////////////////
+
+/// Signed5Bit is somewhat special-purpose for instructions such as
+/// JPX which use the instruction's configuration value as a 5-bit
+/// signed integer.
+#[derive(Clone, Copy)]
+pub struct Signed5Bit {
+    pub(crate) bits: u8,
+}
+
+signed_ones_complement_impl!(Signed5Bit, 5, u8, i8, Unsigned5Bit);
+
+// We only support a limited set of conversions.
+
+// i8 -> Signed5Bit
+// u8 -> Signed5Bit
+try_from_native_type_to_self!(Signed5Bit, u8, i8, i8 u8);
+
+// Signed5Bit -> i8
+from_self_to_native_type!(Signed5Bit, u8, i8, i8);
+try_from_self_to_native_type!(Signed5Bit, u8, i8, u8);
+
+////////////////////////////////////////////////////////////////////////
+// Signed6Bit
+////////////////////////////////////////////////////////////////////////
+
+/// Signed6Bit is somewhat special-purpose as the signed counterpart
+/// for Unsigned6Bit, which is for handlng index register numbers and
+/// sequence numbers.
+#[derive(Clone, Copy)]
+pub struct Signed6Bit {
+    pub(crate) bits: u8,
+}
+
+signed_ones_complement_impl!(Signed6Bit, 6, u8, i8, Unsigned6Bit);
+
+// We only support a limited set of conversions.
+
+// i8 -> Signed6Bit
+// u8 -> Signed6Bit
+try_from_native_type_to_self!(Signed6Bit, u8, i8, i8 u8);
+
+// Signed6Bit -> i8
+from_self_to_native_type!(Signed6Bit, u8, i8, i8);
+try_from_self_to_native_type!(Signed6Bit, u8, i8, u8);
+
+////////////////////////////////////////////////////////////////////////
+// Signed9Bit
+////////////////////////////////////////////////////////////////////////
+
+/// Signed counterpart of [`Unsigned9Bit`].
+#[derive(Clone, Copy)]
+pub struct Signed9Bit {
+    pub(crate) bits: u16,
+}
+
+signed_ones_complement_impl!(Signed9Bit, 9, u16, i16, Unsigned9Bit);
+
+// i8 -> Signed9Bit
+// u8 -> Signed9Bit
+from_native_type_to_self!(Signed9Bit, u16, i16, i8 u8);
+
+// i16 -> Signed9Bit
+// u16 -> Signed9Bit
+// i32 -> Signed9Bit
+// u32 -> Signed9Bit
+// i64 -> Signed9Bit
+// u64 -> Signed9Bit
+try_from_native_type_to_self!(Signed9Bit, u16, i16, i16 u16 i32 u32 i64 u64);
+
+// Signed9Bit -> i8
+// Signed9Bit -> u8
+try_from_self_to_native_type!(Signed9Bit, u16, i16, i8 u8);
+
+// Signed9Bit -> i16
+from_self_to_native_type!(Signed9Bit, u16, i16, i16);
+// Signed9Bit -> u16
+try_from_self_to_native_type!(Signed9Bit, u16, i16, u16);
+// Signed9Bit -> i32
+from_self_to_native_type!(Signed9Bit, u16, i16, i32);
+// Signed9Bit -> u32
+try_from_self_to_native_type!(Signed9Bit, u16, i16, u32);
+// Signed9Bit -> i64
+from_self_to_native_type!(Signed9Bit, u16, i16, i64);
+// Signed9Bit -> u64
+try_from_self_to_native_type!(Signed9Bit, u16, i16, u64);
+
+////////////////////////////////////////////////////////////////////////
+// Signed18Bit
+////////////////////////////////////////////////////////////////////////
+
+
+/// Signed counterpart of [`Unsigned18Bit`].
+#[derive(Clone, Copy)]
+pub struct Signed18Bit {
+    pub(crate) bits: u32,
+}
+
+// i8 -> Signed18Bit
+// u8 -> Signed18Bit
+// i16 -> Signed18Bit
+// u16 -> Signed18Bit
+from_native_type_to_self!(Signed18Bit, u32, i32, i8 u8 i16 u16);
+
+// i32 -> Signed18Bit
+// u32 -> Signed18Bit
+// i64 -> Signed18Bit
+// u64 -> Signed18Bit
+try_from_native_type_to_self!(Signed18Bit, u32, i32, i32 u32 i64 u64);
+
+// Signed18Bit -> i8
+// Signed18Bit -> u8
+// Signed18Bit -> i16
+// Signed18Bit -> u16
+try_from_self_to_native_type!(Signed18Bit, u32, i32, i8 u8 i16 u16);
+
+// Signed18Bit -> i32
+from_self_to_native_type!(Signed18Bit, u32, i32, i32);
+// Signed18Bit -> u32
+try_from_self_to_native_type!(Signed18Bit, u32, i32, u32);
+// Signed18Bit -> i64
+from_self_to_native_type!(Signed18Bit, u32, i32, i64);
+// Signed18Bit -> u64
+try_from_self_to_native_type!(Signed18Bit, u32, i32, u64);
+
+signed_ones_complement_impl!(Signed18Bit, 18, u32, i32, Unsigned18Bit);
+
+////////////////////////////////////////////////////////////////////////
+// Signed36Bit
+////////////////////////////////////////////////////////////////////////
+
+/// Signed counterpart of [`Unsigned36Bit`].
+#[derive(Clone, Copy)]
+pub struct Signed36Bit {
+    pub(crate) bits: u64,
+}
+
+// i8 -> Signed36Bit
+// u8 -> Signed36Bit
+// i16 -> Signed36Bit
+// u16 -> Signed36Bit
+// i32 -> Signed36Bit
+// u32 -> Signed36Bit
+from_native_type_to_self!(Signed36Bit, u64, i64, i8 u8 i16 u16 i32 u32);
+
+// i64 -> Signed36Bit
+// u64 -> Signed36Bit
+try_from_native_type_to_self!(Signed36Bit, u64, i64, i64 u64);
+
+// Signed36Bit -> i8
+// Signed36Bit -> u8
+// Signed36Bit -> i16
+// Signed36Bit -> u16
+// Signed36Bit -> i32
+// Signed36Bit -> u32
+try_from_self_to_native_type!(Signed36Bit, u64, i64, i8 u8 i16 u16 i32 u32);
+
+// Signed36Bit -> i64
+from_self_to_native_type!(Signed36Bit, u64, i64, i64);
+// Signed36Bit -> u64
+try_from_self_to_native_type!(Signed36Bit, u64, i64, u64);
+
+signed_ones_complement_impl!(Signed36Bit, 36, u64, i64, Unsigned36Bit);
+
+
+
+
+impl TryFrom<Unsigned18Bit> for Signed18Bit {
+    type Error = ConversionFailed;
+    fn try_from(n: Unsigned18Bit) -> Result<Self, ConversionFailed> {
+	let val: i32 = i32::from(n);
+	Signed18Bit::try_from(val)
+    }
+}
+
+impl From<Signed5Bit> for Signed18Bit {
+    fn from(n: Signed5Bit) -> Self {
+	Signed18Bit::from(i8::from(n))
+    }
+}
+
+impl From<Signed6Bit> for Signed18Bit {
+    fn from(n: Signed6Bit) -> Self {
+	Signed18Bit::from(i8::from(n))
+    }
+}
+
+impl From<Signed9Bit> for Signed18Bit {
+    fn from(n: Signed9Bit) -> Self {
+	Signed18Bit::from(i16::from(n))
+    }
+}

--- a/base/src/onescomplement/signed/tests18.rs
+++ b/base/src/onescomplement/signed/tests18.rs
@@ -1,0 +1,444 @@
+use super::{ConversionFailed, Signed18Bit};
+
+macro_rules! assert_octal_eq {
+    ($left:expr, $right:expr $(,)?) => {{
+        match (&$left, &$right) {
+            (left_val, right_val) => {
+                if !(*left_val == *right_val) {
+                    panic!(
+                        "Assertion failed: {:>#012o} != {:>#012o}",
+                        left_val, right_val
+                    );
+                }
+            }
+        }
+    }};
+}
+
+#[test]
+fn test_signed18_max_value() {
+    assert_eq!(u64::try_from(Signed18Bit::MAX), Ok(0o377_777_u64));
+    assert_eq!(u32::try_from(Signed18Bit::MAX), Ok(0o377_777_u32));
+    assert_eq!(i64::from(Signed18Bit::MAX), 0o377_777 as i64);
+    assert_eq!(i32::from(Signed18Bit::MAX), 0o377_777 as i32);
+}
+
+#[test]
+fn test_signed18_max_range() {
+    assert!(u8::try_from(Signed18Bit::MAX).is_err());
+    assert!(i8::try_from(Signed18Bit::MAX).is_err());
+}
+
+#[test]
+fn test_signed18_min_value() {
+    assert_eq!(i64::from(Signed18Bit::MIN), -(0o377_777 as i64));
+    assert_eq!(i32::from(Signed18Bit::MIN), -(0o377_777 as i32));
+}
+
+#[test]
+fn test_signed18_min_range() {
+    assert!(u64::try_from(Signed18Bit::MIN).is_err());
+    assert!(u32::try_from(Signed18Bit::MIN).is_err());
+    assert!(u16::try_from(Signed18Bit::MIN).is_err());
+    assert!(u8::try_from(Signed18Bit::MIN).is_err());
+}
+
+#[test]
+fn test_from_u8() {
+    assert_eq!(Signed18Bit::from(0_u8), Signed18Bit::ZERO);
+    assert_eq!(Signed18Bit::from(1_u8), Signed18Bit::ONE);
+    assert_eq!(Signed18Bit::from(0_u8).bits, 0_u32);
+    assert_eq!(Signed18Bit::from(1_u8).bits, 1_u32);
+    assert_eq!(Signed18Bit::from(0o377_u8).bits, 0o377_u32);
+}
+
+#[test]
+fn test_try_from_signed18bit_u8() {
+    assert_eq!(u8::try_from(Signed18Bit::ONE), Ok(1_u8));
+    assert_eq!(u8::try_from(Signed18Bit::ZERO), Ok(0_u8));
+    assert_eq!(u8::try_from(Signed18Bit::from(1_u8)), Ok(1_u8));
+    assert_eq!(u8::try_from(Signed18Bit::from(0o377_u8)), Ok(0o377_u8));
+    assert_eq!(
+        u8::try_from(Signed18Bit {
+            bits: 0b011_111_111_u32
+        }),
+        Ok(0o377_u8)
+    );
+    assert_eq!(
+        u8::try_from(Signed18Bit {
+            bits: 0o777_776_u32
+        }), // -1
+        Err(ConversionFailed::TooSmall)
+    );
+    assert_eq!(
+        u8::try_from(Signed18Bit {
+            bits: 0o777_677_u32
+        }), // -127
+        Err(ConversionFailed::TooSmall)
+    );
+}
+
+#[test]
+fn test_i8_round_tripping() {
+    let mut prev: Option<Signed18Bit> = None;
+    for i in i8::MIN..i8::MAX {
+        let q: Signed18Bit = Signed18Bit::from(i);
+        if let Some(qprev) = prev {
+            assert!(
+                q > qprev,
+                "failed to round-trip {}: {:?} should be greater than {:?}",
+                i,
+                q,
+                qprev
+            );
+        }
+        prev = Some(q);
+        match i8::try_from(q) {
+            Ok(out) => {
+                assert_eq!(i, out, "Round trip failed for {}->{:?}->{}", i, &q, out);
+            }
+            Err(e) => {
+                panic!(
+		    "Unexpected overflow when round-tripping  {}->{:?}-> [conversion to i8 failed with error {}]",
+		    i, &q, e);
+            }
+        }
+    }
+}
+
+#[test]
+fn test_i16_round_tripping() {
+    let mut prev: Option<Signed18Bit> = None;
+    for i in i16::MIN..i16::MAX {
+        let q: Signed18Bit = Signed18Bit::from(i);
+        if let Some(qprev) = prev {
+            assert!(
+                q > qprev,
+                "failed to round-trip {}: {:?} should be greater than {:?}",
+                i,
+                q,
+                qprev
+            );
+        }
+        prev = Some(q);
+        match i16::try_from(q) {
+            Ok(out) => {
+                assert_eq!(i, out, "Round trip failed for {}->{:?}->{}", i, &q, out);
+            }
+            Err(e) => {
+                panic!(
+		    "Unexpected overflow when round-tripping  {}->{:?}-> [conversion to i8 failed with error {}]",
+		    i, &q, e);
+            }
+        }
+    }
+}
+
+#[test]
+fn test_u8_round_tripping() {
+    let mut prev: Option<Signed18Bit> = None;
+    for i in u8::MIN..u8::MAX {
+        let q: Signed18Bit = Signed18Bit::from(i);
+        if let Some(qprev) = prev {
+            assert!(
+                q > qprev,
+                "failed to round-trip {}: {:?} should be greater than {:?}",
+                i,
+                q,
+                qprev
+            );
+        }
+        prev = Some(q);
+        match u8::try_from(q) {
+            Ok(out) => {
+                assert_eq!(i, out, "Round trip failed for {}->{:?}->{}", i, &q, out);
+            }
+            Err(e) => {
+                panic!(
+		    "Unexpected overflow when round-tripping  {}->{:?}-> [conversion to i8 failed with error {}]",
+		    i, &q, e);
+            }
+        }
+    }
+}
+
+#[test]
+fn test_u16_round_tripping() {
+    let mut prev: Option<Signed18Bit> = None;
+    for i in u16::MIN..u16::MAX {
+        let q: Signed18Bit = Signed18Bit::from(i);
+        if let Some(qprev) = prev {
+            assert!(
+                q > qprev,
+                "failed to round-trip {}: {:?} should be greater than {:?}",
+                i,
+                q,
+                qprev
+            );
+        }
+        prev = Some(q);
+        match u16::try_from(q) {
+            Ok(out) => {
+                assert_eq!(i, out, "Round trip failed for {}->{:?}->{}", i, &q, out);
+            }
+            Err(e) => {
+                panic!(
+		    "Unexpected overflow when round-tripping  {}->{:?}-> [conversion to i8 failed with error {}]",
+		    i, &q, e);
+            }
+        }
+    }
+}
+
+#[test]
+fn test_convert_to_ones_complement() {
+    assert_octal_eq!(Signed18Bit::convert_to_ones_complement(0_i32), 0_u32);
+    assert_octal_eq!(Signed18Bit::convert_to_ones_complement(1_i32), 1_u32);
+    assert_octal_eq!(
+        Signed18Bit::convert_to_ones_complement(-1_i32),
+        0o777_776_u32
+    );
+}
+
+#[test]
+fn test_from_i16_signed18bit() {
+    assert_octal_eq!(Signed18Bit::ZERO.bits, 0_u32);
+    assert_octal_eq!(Signed18Bit::ONE.bits, 1_u32);
+    assert_octal_eq!(Signed18Bit::from(127_i16).bits, 127_u32);
+    // octal because binary gets awkwardly long
+    // Self::bits has 1 sign
+    assert_octal_eq!(Signed18Bit::from(1_i16).bits, 0o000_001_u32); //  ( 2^0)
+    assert_octal_eq!(Signed18Bit::from(2_i16).bits, 0o000_002_u32); //  ( 2^1)
+    assert_octal_eq!(Signed18Bit::from(4_i16).bits, 0o000_004_u32); //  ( 2^2)
+    assert_octal_eq!(Signed18Bit::from(8_i16).bits, 0o000_010_u32); //  ( 2^3)
+    assert_octal_eq!(Signed18Bit::from(16_i16).bits, 0o000_020_u32); //  ( 2^4)
+    assert_octal_eq!(Signed18Bit::from(32_i16).bits, 0o000_040_u32); //  ( 2^5)
+    assert_octal_eq!(Signed18Bit::from(64_i16).bits, 0o000_100_u32); //  ( 2^6)
+    assert_octal_eq!(Signed18Bit::from(128_i16).bits, 0o000_200_u32); //  ( 2^7)
+    assert_octal_eq!(Signed18Bit::from(256_i16).bits, 0o000_400_u32); //  ( 2^8)
+    assert_octal_eq!(Signed18Bit::from(512_i16).bits, 0o001_000_u32); //  ( 2^9)
+    assert_octal_eq!(Signed18Bit::from(1024_i16).bits, 0o002_000_u32); //  (2^10)
+    assert_octal_eq!(Signed18Bit::from(2048_i16).bits, 0o004_000_u32); //  (2^11)
+    assert_octal_eq!(Signed18Bit::from(4096_i16).bits, 0o010_000_u32); //  (2^12)
+    assert_octal_eq!(Signed18Bit::from(8192_i16).bits, 0o020_000_u32); //  (2^13)
+    assert_octal_eq!(Signed18Bit::from(16384_i16).bits, 0o040_000_u32); //  (2^14)
+
+    assert_octal_eq!(Signed18Bit::from(-1_i16).bits, 0o777_776_u32); // -( 2^0)
+    assert_octal_eq!(Signed18Bit::from(-2_i16).bits, 0o777_775_u32); // -( 2^1)
+    assert_octal_eq!(Signed18Bit::from(-4_i16).bits, 0o777_773_u32); // -( 2^2)
+    assert_octal_eq!(Signed18Bit::from(-8_i16).bits, 0o777_767_u32); // -( 2^3)
+    assert_octal_eq!(Signed18Bit::from(-16_i16).bits, 0o777_757_u32); // -( 2^4)
+    assert_octal_eq!(Signed18Bit::from(-32_i16).bits, 0o777_737_u32); // -( 2^5)
+    assert_octal_eq!(Signed18Bit::from(-64_i16).bits, 0o777_677_u32); // -( 2^6)
+    assert_octal_eq!(Signed18Bit::from(-128_i16).bits, 0o777_577_u32); // -( 2^7)
+    assert_octal_eq!(Signed18Bit::from(-256_i16).bits, 0o777_377_u32); // -( 2^8)
+    assert_octal_eq!(Signed18Bit::from(-512_i16).bits, 0o776_777_u32); // -( 2^9)
+    assert_octal_eq!(Signed18Bit::from(-1024_i16).bits, 0o775_777_u32); // -(2^10)
+    assert_octal_eq!(Signed18Bit::from(-2048_i16).bits, 0o773_777_u32); // -(2^11)
+    assert_octal_eq!(Signed18Bit::from(-4096_i16).bits, 0o767_777_u32); // -(2^12)
+    assert_octal_eq!(Signed18Bit::from(-8192_i16).bits, 0o757_777_u32); // -(2^13)
+    assert_octal_eq!(Signed18Bit::from(-16384_i16).bits, 0o737_777_u32); // -(2^14)
+    assert_octal_eq!(Signed18Bit::from(-32768_i16).bits, 0o677_777_u32); // -(2^15)
+}
+
+#[test]
+fn test_from_i32_signed18bit() {
+    assert_octal_eq!(
+        Signed18Bit::try_from(32768_i32).unwrap().bits,
+        0o100_000_u32
+    );
+    assert_octal_eq!(
+        Signed18Bit::try_from(65536_i32).unwrap().bits,
+        0o200_000_u32
+    );
+}
+
+#[test]
+fn test_signed18bit_zero_values() {
+    const MINUS_ZERO: Signed18Bit = Signed18Bit {
+        bits: (1 << 18) - 1_u32,
+    };
+    assert_eq!(
+        i8::try_from(MINUS_ZERO),
+        Ok(0_i8),
+        "-0 should convert to 0_i8"
+    );
+    const PLUS_ZERO: Signed18Bit = Signed18Bit {
+        bits: 0b000_000_000_u32,
+    };
+    assert_eq!(
+        i8::try_from(PLUS_ZERO),
+        Ok(0_i8),
+        "+0 should convert to 0_i8"
+    );
+    assert_eq!(PLUS_ZERO, MINUS_ZERO); // need to implement PartialEq first.
+}
+
+#[test]
+fn test_from_signed18bit_to_i8() {
+    assert_eq!(i8::try_from(Signed18Bit::ZERO), Ok(0_i8));
+    assert_eq!(i8::try_from(Signed18Bit::ONE), Ok(1_i8));
+    assert_eq!(i8::try_from(Signed18Bit { bits: 127_u32 }), Ok(127_i8));
+    assert_eq!(
+        i8::try_from(Signed18Bit {
+            bits: 0o777_776_u32
+        }),
+        Ok(-1_i8)
+    );
+    assert_eq!(
+        i8::try_from(Signed18Bit {
+            bits: 0o777_775_u32
+        }),
+        Ok(-2_i8)
+    );
+    assert_eq!(
+        i8::try_from(Signed18Bit {
+            bits: 0o777_675_u32
+        }),
+        Ok(-66_i8)
+    );
+    assert_eq!(
+        i8::try_from(Signed18Bit {
+            bits: 0o777_600_u32
+        }),
+        Ok(-127_i8)
+    );
+    assert!(dbg!(i8::try_from(dbg!(Signed18Bit::MAX))).is_err());
+    assert!(i8::try_from(Signed18Bit::MIN).is_err());
+}
+
+#[test]
+fn test_from_signed18bit_to_i16() {
+    assert_eq!(i16::try_from(Signed18Bit::ZERO), Ok(0_i16));
+    assert_eq!(i16::try_from(Signed18Bit::ONE), Ok(1_i16));
+    assert_eq!(i16::try_from(Signed18Bit { bits: 127_u32 }), Ok(127_i16));
+    assert_eq!(
+        i16::try_from(Signed18Bit { bits: 32767_u32 }),
+        Ok(32767_i16)
+    );
+    assert!(i16::try_from(Signed18Bit::MAX).is_err());
+    assert!(i16::try_from(Signed18Bit::MIN).is_err());
+}
+
+#[test]
+fn test_from_u16_to_signed18bit() {
+    assert_eq!(Signed18Bit::try_from(0_u16), Ok(Signed18Bit::ZERO));
+    assert_eq!(Signed18Bit::try_from(1_u16), Ok(Signed18Bit::ONE));
+    assert_eq!(Signed18Bit::from(0o377_u16).bits, 0o000_000_377_u32);
+}
+
+#[test]
+fn test_from_signed18bit_to_u16() {
+    assert_eq!(u16::try_from(Signed18Bit::ZERO), Ok(0));
+    assert_eq!(u16::try_from(Signed18Bit::ONE), Ok(1));
+    assert_eq!(
+        u16::try_from(Signed18Bit { bits: 0o377_u32 }),
+        Ok(0o377_u16)
+    );
+    assert_eq!(
+        u16::try_from(Signed18Bit {
+            bits: 0o400_000_u32
+        }),
+        Err(ConversionFailed::TooSmall)
+    );
+    assert_eq!(
+        u16::try_from(Signed18Bit {
+            bits: 0o477_000_u32
+        }),
+        Err(ConversionFailed::TooSmall)
+    );
+}
+
+#[test]
+fn test_signed18bit_ord() {
+    assert!(Signed18Bit::ZERO < Signed18Bit::ONE);
+    assert!(!(Signed18Bit::ONE < Signed18Bit::ZERO));
+    assert!(!(Signed18Bit::ZERO < Signed18Bit::ZERO));
+    assert!(!(Signed18Bit::ONE < Signed18Bit::ONE));
+
+    assert!(Signed18Bit::ONE > Signed18Bit::ZERO);
+    assert!(!(Signed18Bit::ZERO > Signed18Bit::ZERO));
+    assert!(!(Signed18Bit::ONE > Signed18Bit::ONE));
+    assert!(!(Signed18Bit::ZERO > Signed18Bit::ONE));
+
+    assert!(Signed18Bit::MIN < Signed18Bit::MAX);
+    assert!(Signed18Bit::MAX > Signed18Bit::MIN);
+}
+
+#[test]
+fn test_signed18bit_eq() {
+    assert_eq!(Signed18Bit::ZERO, Signed18Bit::ZERO);
+    assert_eq!(Signed18Bit::ONE, Signed18Bit::ONE);
+
+    let another_one: Signed18Bit = Signed18Bit::from(1_i8);
+    assert_eq!(
+        Signed18Bit::ONE, another_one,
+        "ensure we don't confuse identity with equality"
+    );
+}
+
+#[test]
+fn test_signed18bit_checked_add() {
+    // Test the basics: adding zero to something leaves it unchanged.
+    assert_eq!(Signed18Bit::ZERO.checked_add(Signed18Bit::ZERO), Some(Signed18Bit::ZERO));
+    assert_eq!(Signed18Bit::ZERO.checked_add(Signed18Bit::ONE), Some(Signed18Bit::ONE));
+    assert_eq!(Signed18Bit::ONE.checked_add(Signed18Bit::ZERO), Some(Signed18Bit::ONE));
+    assert_eq!(Signed18Bit::MAX.checked_add(Signed18Bit::ZERO), Some(Signed18Bit::MAX));
+    assert_eq!(Signed18Bit::MIN.checked_add(Signed18Bit::ZERO), Some(Signed18Bit::MIN));
+
+    // Test the basics: 1+1=2
+    let two: Signed18Bit = Signed18Bit::from(2_i8);
+    assert_eq!(Signed18Bit::ONE.checked_add(Signed18Bit::ONE), Some(two));
+
+    // Verify that we correctly detect overflow
+    assert_eq!(Signed18Bit::MAX.checked_add(Signed18Bit::ONE), None);
+
+    let minus_one: Signed18Bit = Signed18Bit::from(-1_i8);
+    assert!(dbg!(minus_one) < Signed18Bit::ZERO);
+    assert_eq!(
+        i32::from(Signed18Bit::MAX.checked_add(minus_one).unwrap()),
+        0o377776_i32
+    );
+    assert_eq!(Signed18Bit::ZERO.checked_add(minus_one).unwrap(), minus_one);
+}
+
+#[test]
+fn test_signed18bit_checked_sub() {
+    let minus_one: Signed18Bit = Signed18Bit::from(-1_i8);
+
+    // Test the basics: adding zero to something leaves it unchanged.
+    assert_eq!(Signed18Bit::ZERO.checked_sub(Signed18Bit::ZERO), Some(Signed18Bit::ZERO));
+    assert_eq!(Signed18Bit::ONE.checked_sub(Signed18Bit::ZERO), Some(Signed18Bit::ONE));
+    assert_eq!(Signed18Bit::MAX.checked_sub(Signed18Bit::ZERO), Some(Signed18Bit::MAX));
+    assert_eq!(Signed18Bit::MIN.checked_sub(Signed18Bit::ZERO), Some(Signed18Bit::MIN));
+
+    // Test the basics: 2-1=1
+    let two: Signed18Bit = Signed18Bit::from(2_i8);
+    assert_eq!(two.checked_sub(Signed18Bit::ONE), Some(Signed18Bit::ONE));
+    assert_eq!(two.checked_sub(two), Some(Signed18Bit::ZERO));
+
+    // Verify that we correctly detect overflow
+    assert_eq!(Signed18Bit::MIN.checked_sub(Signed18Bit::ONE), None);
+
+    assert_eq!(
+        i32::from(Signed18Bit::MAX.checked_sub(Signed18Bit::ONE).unwrap()),
+        0o377776_i32
+    );
+    assert_eq!(Signed18Bit::ZERO.checked_sub(Signed18Bit::ONE).unwrap(), minus_one);
+}
+
+#[test]
+fn test_signed18bit_abs() {
+    let minus_one: Signed18Bit = Signed18Bit::from(-1_i8);
+    assert_eq!(Signed18Bit::ZERO, Signed18Bit::ZERO.abs());
+    assert_eq!(Signed18Bit::ONE, Signed18Bit::ONE.abs());
+    assert_eq!(Signed18Bit::ONE, minus_one.abs());
+}
+
+#[test]
+fn test_signed18bit_checked_abs() {
+    let minus_one: Signed18Bit = Signed18Bit::from(-1_i8);
+    assert_eq!((Signed18Bit::ZERO, false), Signed18Bit::ZERO.overflowing_abs());
+    assert_eq!((Signed18Bit::ONE, false), Signed18Bit::ONE.overflowing_abs());
+    assert_eq!((Signed18Bit::ONE, false), minus_one.overflowing_abs());
+}

--- a/base/src/onescomplement/signed/tests36.rs
+++ b/base/src/onescomplement/signed/tests36.rs
@@ -1,0 +1,137 @@
+use super::{ConversionFailed, Signed36Bit};
+
+macro_rules! assert_octal_eq {
+    ($left:expr, $right:expr $(,)?) => {{
+        match (&$left, &$right) {
+            (left_val, right_val) => {
+                if !(*left_val == *right_val) {
+                    panic!(
+                        "Assertion failed: {:>#012o} != {:>#012o}",
+                        left_val, right_val
+                    );
+                }
+            }
+        }
+    }};
+}
+
+#[test]
+fn test_signed36_max_value() {
+    assert_eq!(u64::try_from(Signed36Bit::MAX), Ok(0o377_777_777_777_u64));
+    assert_eq!(i64::from(Signed36Bit::MAX), 0o377_777_777_777_i64);
+}
+
+#[test]
+fn test_signed36_min_value() {
+    assert_eq!(i64::from(Signed36Bit::MIN), -0o377_777_777_777_i64);
+}
+
+#[test]
+fn test_signed36_min_range() {
+    dbg!(&Signed36Bit::MIN);
+    assert!(dbg!(u64::try_from(Signed36Bit::MIN)).is_err());
+    assert!(dbg!(u32::try_from(Signed36Bit::MIN)).is_err());
+    assert!(dbg!(u16::try_from(Signed36Bit::MIN)).is_err());
+    assert!(dbg!(u8::try_from(Signed36Bit::MIN)).is_err());
+}
+
+#[test]
+fn test_from_u8() {
+    assert_eq!(Signed36Bit::from(0_u8).bits, 0_u64);
+    assert_eq!(Signed36Bit::from(1_u8).bits, 1_u64);
+    assert_eq!(Signed36Bit::from(0o377_u8).bits, 0o377_u64);
+}
+
+#[test]
+fn test_try_from_signed36bit_u8() {
+    assert_eq!(u8::try_from(Signed36Bit::from(0_u8)), Ok(0_u8));
+    assert_eq!(u8::try_from(Signed36Bit::from(1_u8)), Ok(1_u8));
+    assert_eq!(u8::try_from(Signed36Bit::from(0o377_u8)), Ok(0o377_u8));
+    assert_eq!(u8::try_from(Signed36Bit::from(0o377_u32)), Ok(0o377_u8));
+    assert_eq!(
+        u8::try_from(Signed36Bit::from(-1_i8)),
+        Err(ConversionFailed::TooSmall)
+    );
+    assert_eq!(
+        u8::try_from(Signed36Bit::from(-127_i8)),
+        Err(ConversionFailed::TooSmall)
+    );
+}
+
+#[test]
+fn test_i16_round_tripping() {
+    let mut prev: Option<Signed36Bit> = None;
+    for i in i16::MIN..i16::MAX {
+        let q: Signed36Bit = Signed36Bit::from(i);
+        if let Some(qprev) = prev {
+            assert!(
+                q > qprev,
+                "failed to round-trip {}: {:?} should be greater than {:?}",
+                i,
+                q,
+                qprev
+            );
+        }
+        prev = Some(q);
+        match i16::try_from(q) {
+            Ok(out) => {
+                assert_eq!(i, out, "Round trip failed for {}->{:?}->{}", i, &q, out);
+            }
+            Err(e) => {
+                panic!(
+		    "Unexpected overflow when round-tripping  {}->{:?}-> [conversion to i8 failed with error {}]",
+		    i, &q, e);
+            }
+        }
+    }
+}
+
+#[test]
+fn test_convert_to_ones_complement() {
+    assert_octal_eq!(
+        Signed36Bit::convert_to_ones_complement(-1_i64),
+        0o777_777_777_776_u64
+    );
+}
+
+#[test]
+fn test_i32_round_tripping() {
+    fn round_trip(input: i32) {
+        let x = Signed36Bit::from(input);
+        let result: i32 = x.try_into().expect("round-trip should work");
+        assert_octal_eq!(input, result);
+    }
+
+    for bitpos in 0..32 {
+        let input: i32 = 1_i32 << bitpos;
+        let (negated, overflow) = input.overflowing_neg();
+        round_trip(input);
+        if !overflow {
+            round_trip(negated);
+        }
+    }
+}
+
+#[test]
+fn test_i64_round_tripping() {
+    fn round_trip(input: i64) {
+        match Signed36Bit::try_from(input) {
+            Err(_) if input >= 0 => {
+                assert!(input >= 1_i64 << 35);
+            }
+            Err(_) => {
+                assert!(input <= -(1_i64 << 35));
+            }
+            Ok(x) => {
+                let result: i64 = x.try_into().expect("round-trip should work");
+                assert_octal_eq!(input, result);
+            }
+        }
+    }
+
+    for bitpos in 0..63 {
+        let input: i64 = 1_i64 << bitpos;
+        round_trip(input);
+        round_trip(-input);
+    }
+}

--- a/base/src/onescomplement/signed/tests5.rs
+++ b/base/src/onescomplement/signed/tests5.rs
@@ -1,0 +1,138 @@
+use super::Signed5Bit;
+
+#[test]
+fn test_from_u8() {
+    assert_eq!(u8::try_from(Signed5Bit::try_from(1_u8).unwrap()), Ok(1_u8)); // 2^0
+    assert_eq!(u8::try_from(Signed5Bit::try_from(2_u8).unwrap()), Ok(2_u8)); // 2^1
+    assert_eq!(u8::try_from(Signed5Bit::try_from(4_u8).unwrap()), Ok(4_u8)); // 2^2
+    assert_eq!(u8::try_from(Signed5Bit::try_from(8_u8).unwrap()), Ok(8_u8)); // 2^3
+    assert!(dbg!(Signed5Bit::try_from(16_u8)).is_err());
+}
+
+#[test]
+fn test_i8_round_tripping() {
+    let mut prev: Option<Signed5Bit> = None;
+    for i in -15_i8..15_i8 {
+        let q: Signed5Bit = Signed5Bit::try_from(i).expect("input is in range");
+        if let Some(qprev) = prev {
+            assert!(
+                q > qprev,
+                "failed to round-trip {}: {:?} should be greater than {:?}",
+                i,
+                q,
+                qprev
+            );
+        }
+        prev = Some(q);
+        let out = i8::from(q);
+        assert_eq!(i, out, "Round trip failed for {}->{:?}->{}", i, &q, out);
+    }
+}
+
+#[test]
+fn test_signed5bit_ord() {
+    let zero: Signed5Bit = Signed5Bit::try_from(0_i8).unwrap();
+    let one: Signed5Bit = Signed5Bit::try_from(1_i8).unwrap();
+    assert!(zero < one);
+    assert!(!(one < zero));
+    assert!(!(zero < zero));
+    assert!(!(one < one));
+
+    assert!(one > zero);
+    assert!(!(zero > zero));
+    assert!(!(one > one));
+    assert!(!(zero > one));
+
+    assert!(Signed5Bit::MIN < Signed5Bit::MAX);
+    assert!(Signed5Bit::MAX > Signed5Bit::MIN);
+}
+
+#[test]
+fn test_signed5bit_eq() {
+    let zero: Signed5Bit = Signed5Bit::try_from(0_i8).unwrap();
+    let one: Signed5Bit = Signed5Bit::try_from(1_i8).unwrap();
+    assert_eq!(zero, zero);
+    assert_eq!(one, one);
+
+    let another_one: Signed5Bit = Signed5Bit::try_from(1_i8).unwrap();
+    assert_eq!(
+        one, another_one,
+        "ensure we don't confuse identy with equality"
+    );
+}
+
+#[test]
+fn test_signed5bit_checked_add() {
+    let zero: Signed5Bit = Signed5Bit::try_from(0_i8).unwrap();
+    let one: Signed5Bit = Signed5Bit::try_from(1_i8).unwrap();
+
+    // Test the basics: adding zero to something leaves it unchanged.
+    assert_eq!(zero.checked_add(zero), Some(zero));
+    assert_eq!(zero.checked_add(one), Some(one));
+    assert_eq!(one.checked_add(zero), Some(one));
+    assert_eq!(Signed5Bit::MAX.checked_add(zero), Some(Signed5Bit::MAX));
+    assert_eq!(Signed5Bit::MIN.checked_add(zero), Some(Signed5Bit::MIN));
+
+    // Test the basics: 1+1=2
+    let two: Signed5Bit = Signed5Bit::try_from(2_i8).unwrap();
+    assert_eq!(one.checked_add(one), Some(two));
+
+    // Verify that we correctly detect overflow
+    assert_eq!(Signed5Bit::MAX.checked_add(one), None);
+
+    let minus_one: Signed5Bit = Signed5Bit::try_from(-1_i8).unwrap();
+    assert!(dbg!(minus_one) < zero);
+
+    // The max value is 15, so subtracting 1 from that shoudl give 14.
+    let max: i8 = i8::from(Signed5Bit::MAX);
+    assert_eq!(max, 15);
+    assert_eq!(
+        i8::from(Signed5Bit::MAX.checked_add(minus_one).unwrap()),
+        14_i8
+    );
+
+    assert_eq!(zero.checked_add(minus_one).unwrap(), minus_one);
+}
+
+#[test]
+fn test_signed5bit_checked_sub() {
+    let zero: Signed5Bit = Signed5Bit::try_from(0_i8).unwrap();
+    let one: Signed5Bit = Signed5Bit::try_from(1_i8).unwrap();
+    let minus_one: Signed5Bit = Signed5Bit::try_from(-1_i8).unwrap();
+
+    // Test the basics: adding zero to something leaves it unchanged.
+    assert_eq!(zero.checked_sub(zero), Some(zero));
+    assert_eq!(one.checked_sub(zero), Some(one));
+    assert_eq!(Signed5Bit::MAX.checked_sub(zero), Some(Signed5Bit::MAX));
+    assert_eq!(Signed5Bit::MIN.checked_sub(zero), Some(Signed5Bit::MIN));
+
+    // Test the basics: 2-1=1
+    let two: Signed5Bit = Signed5Bit::try_from(2_i8).unwrap();
+    assert_eq!(two.checked_sub(one), Some(one));
+    assert_eq!(two.checked_sub(two), Some(zero));
+
+    // Verify that we correctly detect overflow
+    assert_eq!(Signed5Bit::MIN.checked_sub(one), None);
+
+    assert_eq!(zero.checked_sub(one).unwrap(), minus_one);
+}
+
+#[test]
+fn test_signed5bit_abs() {
+    let zero: Signed5Bit = Signed5Bit::try_from(0_i8).unwrap();
+    let one: Signed5Bit = Signed5Bit::try_from(1_i8).unwrap();
+    let minus_one: Signed5Bit = Signed5Bit::try_from(-1_i8).unwrap();
+    assert_eq!(zero, zero.abs());
+    assert_eq!(one, one.abs());
+    assert_eq!(one, minus_one.abs());
+}
+
+#[test]
+fn test_signed5bit_checked_abs() {
+    let zero: Signed5Bit = Signed5Bit::try_from(0_i8).unwrap();
+    let one: Signed5Bit = Signed5Bit::try_from(1_i8).unwrap();
+    let minus_one: Signed5Bit = Signed5Bit::try_from(-1_i8).unwrap();
+    assert_eq!((zero, false), zero.overflowing_abs());
+    assert_eq!((one, false), one.overflowing_abs());
+    assert_eq!((one, false), minus_one.overflowing_abs());
+}

--- a/base/src/onescomplement/signed/tests9.rs
+++ b/base/src/onescomplement/signed/tests9.rs
@@ -1,0 +1,343 @@
+use super::{ConversionFailed, Signed9Bit};
+
+macro_rules! assert_octal_eq {
+    ($left:expr, $right:expr $(,)?) => {{
+        match (&$left, &$right) {
+            (left_val, right_val) => {
+                if !(*left_val == *right_val) {
+                    panic!(
+                        "Assertion failed: {:>#012o} != {:>#012o}",
+                        left_val, right_val
+                    );
+                }
+            }
+        }
+    }};
+}
+
+#[test]
+fn test_from_u8() {
+    assert_eq!(Signed9Bit::from(0_u8).bits, 0_u16);
+    assert_eq!(Signed9Bit::from(1_u8).bits, 1_u16);
+    assert_eq!(Signed9Bit::from(0o377_u8).bits, 0o377_u16);
+}
+
+#[test]
+fn test_try_from_signed9bit_u8() {
+    assert_eq!(u8::try_from(Signed9Bit::from(0_u8)), Ok(0_u8));
+    assert_eq!(u8::try_from(Signed9Bit::from(1_u8)), Ok(1_u8));
+    assert_eq!(u8::try_from(Signed9Bit::from(0o377_u8)), Ok(0o377_u8));
+    assert_eq!(
+        u8::try_from(Signed9Bit {
+            bits: 0b011_111_111_u16
+        }),
+        Ok(0o377_u8)
+    );
+    assert_eq!(
+        u8::try_from(Signed9Bit {
+            bits: 0b111_111_110_u16
+        }), // -1
+        Err(ConversionFailed::TooSmall)
+    );
+    assert_eq!(
+        u8::try_from(Signed9Bit {
+            bits: 0b110_000_000_u16
+        }), // -127
+        Err(ConversionFailed::TooSmall)
+    );
+}
+
+#[test]
+fn test_i8_round_tripping() {
+    let mut prev: Option<Signed9Bit> = None;
+    for i in i8::MIN..i8::MAX {
+        let q: Signed9Bit = Signed9Bit::from(i);
+        if let Some(qprev) = prev {
+            assert!(
+                q > qprev,
+                "failed to round-trip {}: {:?} should be greater than {:?}",
+                i,
+                q,
+                qprev
+            );
+        }
+        prev = Some(q);
+        match i8::try_from(q) {
+            Ok(out) => {
+                assert_eq!(i, out, "Round trip failed for {}->{:?}->{}", i, &q, out);
+            }
+            Err(e) => {
+                panic!(
+		    "Unexpected overflow when round-tripping  {}->{:?}-> [conversion to i8 failed with error {}]",
+		    i, &q, e);
+            }
+        }
+    }
+}
+
+#[test]
+fn test_u8_round_tripping() {
+    let mut prev: Option<Signed9Bit> = None;
+    for i in u8::MIN..u8::MAX {
+        let q: Signed9Bit = Signed9Bit::from(i);
+        if let Some(qprev) = prev {
+            assert!(
+                q > qprev,
+                "failed to round-trip {}: {:?} should be greater than {:?}",
+                i,
+                q,
+                qprev
+            );
+        }
+        prev = Some(q);
+        match u8::try_from(q) {
+            Ok(out) => {
+                assert_eq!(i, out, "Round trip failed for {}->{:?}->{}", i, &q, out);
+            }
+            Err(e) => {
+                panic!(
+		    "Unexpected overflow when round-tripping  {}->{:?}-> [conversion to i8 failed with error {}]",
+		    i, &q, e);
+            }
+        }
+    }
+}
+
+#[test]
+fn test_try_from_i8_signed9bit() {
+    assert_octal_eq!(Signed9Bit::from(0_i8).bits, 0_u16);
+    assert_octal_eq!(Signed9Bit::from(1_i8).bits, 1_u16);
+    assert_octal_eq!(Signed9Bit::from(127_i8).bits, 127_u16);
+    assert_octal_eq!(Signed9Bit::from(-1_i8).bits, 0b111_111_110_u16);
+    assert_octal_eq!(Signed9Bit::from(-2_i8).bits, 0b111_111_101_u16);
+    assert_octal_eq!(Signed9Bit::from(-8_i8).bits, 0b111_110_111_u16);
+    assert_octal_eq!(Signed9Bit::from(-32_i8).bits, 0b111_011_111_u16);
+    assert_octal_eq!(Signed9Bit::from(-64_i8).bits, 0b110_111_111_u16);
+    assert_octal_eq!(Signed9Bit::from(-65_i8).bits, 0b110_111_110_u16);
+    assert_octal_eq!(Signed9Bit::from(-66_i8).bits, 0b110_111_101_u16);
+    assert_octal_eq!(Signed9Bit::from(-127_i8).bits, 0b110_000_000_u16);
+    assert_octal_eq!(Signed9Bit::from(-128_i8).bits, 0b101_111_111_u16);
+}
+
+#[test]
+fn test_signed9bit_zero_values() {
+    const MINUS_ZERO: Signed9Bit = Signed9Bit {
+        bits: 0b111_111_111_u16,
+    };
+    assert_eq!(
+        i8::try_from(MINUS_ZERO),
+        Ok(0_i8),
+        "-0 should convert to 0_i8"
+    );
+    const PLUS_ZERO: Signed9Bit = Signed9Bit {
+        bits: 0b000_000_000_u16,
+    };
+    assert_eq!(
+        i8::try_from(PLUS_ZERO),
+        Ok(0_i8),
+        "+0 should convert to 0_i8"
+    );
+    // assert_eq!(PLUS_ZERO, MINUS_ZERO);   // need to implement PartialEq first.
+}
+
+#[test]
+fn test_from_signed9bit_to_i8() {
+    assert_eq!(i8::try_from(Signed9Bit { bits: 0 }), Ok(0_i8));
+    assert_eq!(i8::try_from(Signed9Bit { bits: 1 }), Ok(1_i8));
+    assert_eq!(i8::try_from(Signed9Bit { bits: 127_u16 }), Ok(127_i8));
+    assert_eq!(
+        i8::try_from(Signed9Bit {
+            bits: 0b111_111_110_u16
+        }),
+        Ok(-1_i8)
+    );
+    assert_eq!(
+        i8::try_from(Signed9Bit {
+            bits: 0b111_111_101_u16
+        }),
+        Ok(-2_i8)
+    );
+    assert_eq!(
+        i8::try_from(Signed9Bit {
+            bits: 0b110_111_101_u16
+        }),
+        Ok(-66_i8)
+    );
+    assert_eq!(
+        i8::try_from(Signed9Bit {
+            bits: 0b110_000_000_u16
+        }),
+        Ok(-127_i8)
+    );
+    assert!(i8::try_from(Signed9Bit::MAX).is_err());
+    assert!(i8::try_from(Signed9Bit::MIN).is_err());
+}
+
+#[test]
+fn test_from_u16_to_signed9bit() {
+    assert_octal_eq!(Signed9Bit::try_from(0_u16).unwrap().bits, 0_u16);
+    assert_octal_eq!(Signed9Bit::try_from(1_u16).unwrap().bits, 1_u16);
+    assert_octal_eq!(
+        Signed9Bit::try_from(0o377_u16).unwrap().bits,
+        0o000_000_377_u16
+    );
+    assert!(Signed9Bit::try_from(0o400_u16).is_err());
+}
+
+#[test]
+fn test_from_signed9bit_to_u16() {
+    assert_eq!(u16::try_from(Signed9Bit { bits: 0 }), Ok(0));
+    assert_eq!(u16::try_from(Signed9Bit { bits: 1 }), Ok(1));
+    assert_eq!(u16::try_from(Signed9Bit { bits: 0o377_u16 }), Ok(0o377_u16));
+    assert_eq!(
+        u16::try_from(Signed9Bit { bits: 0o400_u16 }),
+        Err(ConversionFailed::TooSmall)
+    );
+    assert_eq!(
+        u16::try_from(Signed9Bit { bits: 0o477_u16 }),
+        Err(ConversionFailed::TooSmall)
+    );
+}
+
+#[test]
+fn test_signed9bit_ord() {
+    let zero: Signed9Bit = Signed9Bit::from(0_i8);
+    let one: Signed9Bit = Signed9Bit::from(1_i8);
+    assert!(zero < one);
+    assert!(!(one < zero));
+    assert!(!(zero < zero));
+    assert!(!(one < one));
+
+    assert!(one > zero);
+    assert!(!(zero > zero));
+    assert!(!(one > one));
+    assert!(!(zero > one));
+
+    assert!(Signed9Bit::MIN < Signed9Bit::MAX);
+    assert!(Signed9Bit::MAX > Signed9Bit::MIN);
+}
+
+#[test]
+fn test_signed9bit_eq() {
+    let zero: Signed9Bit = Signed9Bit::from(0_i8);
+    let one: Signed9Bit = Signed9Bit::from(1_i8);
+    assert_eq!(zero, zero);
+    assert_eq!(one, one);
+
+    let another_one: Signed9Bit = Signed9Bit::from(1_i8);
+    assert_eq!(
+        one, another_one,
+        "ensure we don't confuse identy with equality"
+    );
+}
+
+#[test]
+fn test_signed9bit_checked_add() {
+    let zero: Signed9Bit = Signed9Bit::from(0_i8);
+    let one: Signed9Bit = Signed9Bit::from(1_i8);
+
+    // Test the basics: adding zero to something leaves it unchanged.
+    assert_eq!(zero.checked_add(zero), Some(zero));
+    assert_eq!(zero.checked_add(one), Some(one));
+    assert_eq!(one.checked_add(zero), Some(one));
+    assert_eq!(Signed9Bit::MAX.checked_add(zero), Some(Signed9Bit::MAX));
+    assert_eq!(Signed9Bit::MIN.checked_add(zero), Some(Signed9Bit::MIN));
+
+    // Test the basics: 1+1=2
+    let two: Signed9Bit = Signed9Bit::from(2_i8);
+    assert_eq!(one.checked_add(one), Some(two));
+
+    // Verify that we correctly detect overflow
+    assert_eq!(Signed9Bit::MAX.checked_add(one), None);
+
+    let minus_one: Signed9Bit = Signed9Bit::from(-1_i8);
+    assert!(dbg!(minus_one) < zero);
+    assert_eq!(
+        i16::from(Signed9Bit::MAX.checked_add(minus_one).unwrap()),
+        254_i16
+    );
+    assert_eq!(zero.checked_add(minus_one).unwrap(), minus_one);
+}
+
+#[test]
+fn test_signed9bit_checked_sub() {
+    let zero: Signed9Bit = Signed9Bit::from(0_i8);
+    let one: Signed9Bit = Signed9Bit::from(1_i8);
+    let minus_one: Signed9Bit = Signed9Bit::from(-1_i8);
+
+    // Test the basics: adding zero to something leaves it unchanged.
+    assert_eq!(zero.checked_sub(zero), Some(zero));
+    assert_eq!(one.checked_sub(zero), Some(one));
+    assert_eq!(Signed9Bit::MAX.checked_sub(zero), Some(Signed9Bit::MAX));
+    assert_eq!(Signed9Bit::MIN.checked_sub(zero), Some(Signed9Bit::MIN));
+
+    // Test the basics: 2-1=1
+    let two: Signed9Bit = Signed9Bit::from(2_i8);
+    assert_eq!(two.checked_sub(one), Some(one));
+    assert_eq!(two.checked_sub(two), Some(zero));
+
+    // Verify that we correctly detect overflow
+    assert_eq!(Signed9Bit::MIN.checked_sub(one), None);
+
+    assert_eq!(
+        i16::from(Signed9Bit::MAX.checked_sub(one).unwrap()),
+        254_i16
+    );
+    assert_eq!(zero.checked_sub(one).unwrap(), minus_one);
+}
+
+#[test]
+fn test_signed9bit_abs() {
+    let zero: Signed9Bit = Signed9Bit::from(0_i8);
+    let one: Signed9Bit = Signed9Bit::from(1_i8);
+    let minus_one: Signed9Bit = Signed9Bit::from(-1_i8);
+    assert_eq!(zero, zero.abs());
+    assert_eq!(one, one.abs());
+    assert_eq!(one, minus_one.abs());
+}
+
+#[test]
+fn test_signed9bit_checked_abs() {
+    let zero: Signed9Bit = Signed9Bit::from(0_i8);
+    let one: Signed9Bit = Signed9Bit::from(1_i8);
+    let minus_one: Signed9Bit = Signed9Bit::from(-1_i8);
+    assert_eq!((zero, false), zero.overflowing_abs());
+    assert_eq!((one, false), one.overflowing_abs());
+    assert_eq!((one, false), minus_one.overflowing_abs());
+}
+
+#[test]
+fn test_wrapping_add() {
+    for left in -255_i16..255_i16 {
+	for right in -255_i16..255_i16 {
+	    let expected = left.wrapping_add(right);
+	    let expected = i16::from(Signed9Bit::try_from(expected % 256).unwrap());
+
+	    let left_operand = Signed9Bit::try_from(left).unwrap();
+	    let right_operand = Signed9Bit::try_from(right).unwrap();
+	    let got = i16::from(left_operand.wrapping_add(right_operand));
+
+	    assert_eq!(expected, got,
+		       "Expected {} + {} = {}, got {:?} + {:?} = {}",
+		       left, right, expected, left_operand, right_operand, got);
+	}
+    }
+}
+
+#[test]
+fn test_wrapping_sub() {
+    for left in -255_i16..255_i16 {
+	for right in -255_i16..255_i16 {
+	    let expected = left.wrapping_sub(right);
+	    let expected = i16::from(Signed9Bit::try_from(expected % 256).unwrap());
+
+	    let left_operand = Signed9Bit::try_from(left).unwrap();
+	    let right_operand = Signed9Bit::try_from(right).unwrap();
+	    let got = i16::from(left_operand.wrapping_sub(right_operand));
+
+	    assert_eq!(expected, got,
+		       "Expected {} + {} = {}, got {:?} + {:?} = {}",
+		       left, right, expected, left_operand, right_operand, got);
+	}
+    }
+}

--- a/base/src/onescomplement/unsigned/mod.rs
+++ b/base/src/onescomplement/unsigned/mod.rs
@@ -1,0 +1,608 @@
+//! This is an implementation of unsigned types of various bit
+//! widths which accompanies the SignedXXBit one's-complement types.
+//! Since these types are unsigned, there is no sign bit and they
+//! aren't really one's-complement types.  But the interface to these
+//! is mostly similar to that of the signed (real one's-complement)
+//! types.
+
+use std::cmp::Ordering;
+use std::fmt::{self, Debug, Display, Formatter, Octal};
+use std::hash::{Hash, Hasher};
+
+use super::error::ConversionFailed;
+use super::{Sign, WordCommon};
+use super::signed::*;
+
+#[cfg(test)]
+mod tests;
+
+/// This macro implements conversions from native types to Unsigned*Bit
+/// which are always possible (e.g. From<u8> for Unsigned9Bit).
+macro_rules! from_native_type_to_self {
+    ($SelfT:ty, $($from:ty)*) => {
+	$(
+	    impl From<$from> for $SelfT {
+		fn from(n: $from) -> Self {
+		    Self {
+			bits: n.into(),
+		    }
+		}
+	    }
+	)*
+    }
+}
+
+/// This macro implements conversions from Unsigned*Bit to native
+/// types which are always possible (e.g. From<Unsigned9Bit> for i16).
+macro_rules! from_self_to_native_type {
+    ($SelfT:ty, $($to:ty)*) => {
+	$(
+	    impl From<$SelfT> for $to {
+		fn from(n: $SelfT) -> $to {
+		    // Note that $InnerT for Unsigned9Bit is u16, and
+		    // from_self_to_native_type is called with $to =
+		    // i16, because the limits of Unsigned9Bit are
+		    // wholly inside the limits of i16.  However,
+		    // since some u16 values call outside the range of
+		    // i16, we cannot use .into() here.  That is, we
+		    // know more about the range of values n.bits can
+		    // take than te compiler knows).
+		    n.bits as $to
+		}
+	    }
+	)*
+    }
+}
+
+/// This macro implements conversions from Unsigned*Bit to native
+/// types where the conversion may not always fit.  For example
+/// TryFrom<Unsigned18Bit> for u8.
+macro_rules! try_from_self_to_native_type {
+    ($SelfT:ty, $($to:ty)*) => {
+	$(
+	    impl TryFrom<$SelfT> for $to {
+		type Error = ConversionFailed;
+		fn try_from(n: $SelfT) -> Result<$to, ConversionFailed> {
+		    <$to>::try_from(n.bits).map_err(|_| ConversionFailed::TooLarge)
+		}
+	    }
+	)*
+    }
+}
+
+/// This macro implements a conversions from native types to
+/// Unsigned*Bit where the conversion may not always fit.  For example
+/// TryFrom<u64> for Unsigned36Bit.
+macro_rules! try_from_native_type_to_self {
+    ($SelfT:ty, $InnerT:ty, $($from:ty)*) => {
+	$(
+	    impl TryFrom<$from> for $SelfT {
+		type Error = ConversionFailed;
+		fn try_from(n: $from) -> Result<Self, ConversionFailed> {
+		    let bits: $InnerT = match n.try_into() {
+			Err(_) => {
+			    // Because $InnerT is unsigned, we know
+			    // that n < 0 is always an error case.
+			    // Since this macro also gets used for
+			    // conversions from unsigned types,
+			    // sometimes this conditional is useless
+			    // (and we expect it to be optimized
+			    // away).
+			    #[allow(unused_comparisons)]
+			    if n < 0 {
+				return Err(ConversionFailed::TooSmall);
+			    } else {
+				return Err(ConversionFailed::TooLarge);
+			    }
+			}
+			Ok(value) if value > Self::VALUE_BITS => {
+			    return Err(ConversionFailed::TooLarge);
+			}
+			Ok(value) => value,
+		    };
+		    Ok(
+			Self {
+			    bits,
+			}
+		    )
+		}
+	    }
+	)*
+    }
+}
+
+/// This macro implements the base functionality of the unsigned
+/// types.  The `SelfT` argument is the name of the (unsigned in this
+/// case) type we are defining.  `BITS` is the bit width of the type
+/// we are defining.  `InnerT` is the name of the native type which
+/// will store those bits.  `SignedPeerT` is the name of the
+/// equivalent signed type having the same width (e.g. for
+/// `Unsigned18Bit` this should be `Signed`8Bit`).
+macro_rules! unsigned_ones_complement_impl {
+    ($SelfT:ty, $BITS:expr, $InnerT:ty, $SignedPeerT:ty) => {
+        impl $SelfT {
+	    const MODULUS: $InnerT = (1 << $BITS);
+            const VALUE_BITS: $InnerT = Self::MODULUS - 1;
+
+            pub const MAX: Self = Self {
+                bits: Self::MODULUS - 1,
+            };
+
+            pub const ZERO: Self = Self { bits: 0 };
+	    pub const ONE: Self = Self { bits: 1 };
+            pub const MIN: Self = Self::ZERO;
+
+            pub const fn is_zero(&self) -> bool {
+                self.bits == 0
+            }
+
+            pub const fn is_negative(&self) -> bool {
+                false
+            }
+
+            pub const fn is_positive(&self) -> bool {
+                true
+            }
+
+	    pub const fn reinterpret_as_signed(&self) -> $SignedPeerT {
+		type T = $SignedPeerT;
+		T {
+		    bits: self.bits
+		}
+	    }
+
+            pub fn wrapping_add(self, rhs: $SelfT) -> $SelfT {
+                let left = <$InnerT>::from(self);
+                let right = <$InnerT>::from(rhs);
+		let in_range_value: $InnerT = left.wrapping_add(right) & Self::VALUE_BITS;
+                Self::try_from(in_range_value).unwrap()
+            }
+
+            pub fn wrapping_sub(self, rhs: $SelfT) -> $SelfT {
+                let left = <$InnerT>::from(self);
+                let right = <$InnerT>::from(rhs);
+                let in_range_value = (left + Self::MODULUS).wrapping_sub(right) & Self::VALUE_BITS;
+                Self::try_from(in_range_value).unwrap()
+            }
+
+            pub fn checked_add(self, rhs: $SelfT) -> Option<$SelfT> {
+                let left = <$InnerT>::from(self);
+                let right = <$InnerT>::from(rhs);
+                match left.checked_add(right) {
+                    Some(result) => Self::try_from(result).ok(),
+                    None => None,
+                }
+            }
+
+            pub fn checked_sub(self, rhs: $SelfT) -> Option<$SelfT> {
+                let left = <$InnerT>::from(self);
+                let right = <$InnerT>::from(rhs);
+                match left.checked_sub(right) {
+                    Some(result) => Self::try_from(result).ok(),
+                    None => None,
+                }
+            }
+
+            pub const fn abs(self) -> Self {
+                self
+            }
+
+            pub const fn overflowing_abs(self) -> (Self, bool) {
+                (self, false)
+            }
+
+            // We cannot call std::ops::And in a const because trait
+            // methods cannot be const.  So we have this work-alike in
+            // impl, since it can be called in a const context.
+            pub const fn and(self, mask: $InnerT) -> Self {
+                Self {
+                    bits: self.bits & mask,
+                }
+            }
+        }
+
+        impl WordCommon for $SelfT {
+            fn signum(&self) -> Sign {
+                if self.is_zero() {
+                    Sign::Zero
+                } else if self.is_negative() {
+                    Sign::Negative
+                } else {
+                    Sign::Positive
+                }
+            }
+        }
+
+        impl Default for $SelfT {
+            fn default() -> Self {
+                Self { bits: 0 }
+            }
+        }
+
+        impl Display for $SelfT {
+            fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+                Octal::fmt(&self.bits, f)
+            }
+        }
+
+        impl Octal for $SelfT {
+            fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+                Octal::fmt(&self.bits, f)
+            }
+        }
+
+        impl Debug for $SelfT {
+            fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+                write!(f, concat!(stringify!($SelfT), "{{bits: {:#o}}}"), self.bits)
+            }
+        }
+
+        impl Hash for $SelfT {
+            fn hash<H>(&self, state: &mut H)
+            where
+                H: Hasher,
+            {
+                self.bits.hash(state)
+            }
+        }
+
+        impl<T> PartialEq<T> for $SelfT
+        where
+            T: TryInto<$SelfT> + Copy,
+        {
+            fn eq(&self, other: &T) -> bool {
+                let converted: Result<$SelfT, _> = (*other).try_into();
+                if let Ok(rhs) = converted {
+                    match self.cmp(&rhs) {
+                        Ordering::Equal => true,
+                        _ => false,
+                    }
+                } else {
+                    false
+                }
+            }
+        }
+
+        impl Eq for $SelfT {}
+
+        impl PartialOrd<$SelfT> for $SelfT {
+            fn partial_cmp(&self, other: &$SelfT) -> Option<Ordering> {
+                Some(self.cmp(other))
+            }
+        }
+
+        impl PartialOrd<u32> for $SelfT {
+            fn partial_cmp(&self, other: &u32) -> Option<Ordering> {
+                match <$SelfT>::try_from(*other) {
+                    Ok(value) => Some(self.cmp(&value)),
+                    // The error case tells us that `other` doesn't fit
+                    // into $SelfT, so `other` must be greater.
+                    Err(_) => Some(Ordering::Less),
+                }
+            }
+        }
+
+        impl PartialOrd<u64> for $SelfT {
+            fn partial_cmp(&self, other: &u64) -> Option<Ordering> {
+                match <$SelfT>::try_from(*other) {
+                    Ok(value) => Some(self.cmp(&value)),
+                    // The error case tells us that `other` doesn't fit
+                    // into $SelfT, so `other` must be greater.
+                    Err(_) => Some(Ordering::Less),
+                }
+            }
+        }
+
+        impl Ord for $SelfT {
+            fn cmp(&self, other: &$SelfT) -> Ordering {
+                // We perform conversion here so that -0 == +0.
+                let lhs = <$InnerT>::from(*self);
+                let rhs = <$InnerT>::from(*other);
+                lhs.cmp(&rhs)
+            }
+        }
+
+        impl std::ops::Not for $SelfT {
+            type Output = Self;
+            fn not(self) -> Self {
+                Self {
+                    bits: (!self.bits) & Self::VALUE_BITS,
+                }
+            }
+        }
+
+        impl std::ops::BitAnd<$InnerT> for $SelfT {
+            type Output = Self;
+            fn bitand(self, mask: $InnerT) -> Self {
+                Self {
+                    bits: self.bits & mask,
+                }
+            }
+        }
+
+        impl std::ops::BitAnd<$SelfT> for $SelfT {
+            type Output = Self;
+            fn bitand(self, rhs: Self) -> Self {
+                self.bitand(rhs.bits)
+            }
+        }
+
+        impl std::ops::BitOr<$InnerT> for $SelfT {
+            type Output = Self;
+            fn bitor(self, mask: $InnerT) -> Self {
+                Self {
+                    bits: self.bits | mask,
+                }
+            }
+        }
+
+        impl std::ops::BitOr for $SelfT {
+            type Output = Self;
+            fn bitor(self, rhs: Self) -> Self {
+                self.bitor(rhs.bits)
+            }
+        }
+
+        impl std::ops::Shr<$SelfT> for $SelfT {
+            type Output = $SelfT;
+            fn shr(self, rhs: Self) -> Self {
+                let shift_by = rhs.bits % $BITS;
+                // Compute a mask which has a 1 in the positions which
+                // we're about to shift off the right of the word.
+                let goners_mask: $InnerT = (1 << shift_by) - 1;
+
+                // Preserve the bits we're about to shift off the
+                // right-hand side.  Although shr() will shift them
+                // back onto the most-significant end of the value,
+                // these are in the wrong position in the word (as
+                // self.bits, being wider than the value we are
+                // representing, has bits which are ignored).
+                let saved = (self.bits & goners_mask) << ($BITS - shift_by);
+
+                let bits = (self.bits.shr(shift_by) | saved) & Self::VALUE_BITS;
+                Self { bits }
+            }
+        }
+
+        impl std::ops::Shr<u32> for $SelfT {
+            type Output = $SelfT;
+            fn shr(self, shift_by: u32) -> Self {
+                // Compute a mask which has a 1 in the positions which
+                // we're about to shift off the right of the word.
+                let goners_mask: $InnerT = (1 << shift_by) - 1;
+
+                // Preserve the bits we're about to shift off the
+                // right-hand side.  Although shr() will shift them
+                // back onto the most-significant end of the value,
+                // these are in the wrong position in the word (as
+                // self.bits, being wider than the value we are
+                // representing, has bits which are ignored).
+                let saved = (self.bits & goners_mask) << ($BITS - shift_by);
+
+                let bits = (self.bits.shr(shift_by) | saved) & Self::VALUE_BITS;
+                Self { bits }
+            }
+        }
+
+        impl std::ops::Shl<$SelfT> for $SelfT {
+            type Output = $SelfT;
+            fn shl(self, shift_by: $SelfT) -> Self {
+		// Clippy is suspicious of the use of the modulus
+		// operation, but this lint check is really intended
+		// to detect things like subtractions inside an add
+		// operation.
+		#[allow(clippy::suspicious_arithmetic_impl)]
+                let shift: u32 = (shift_by.bits % $BITS) as u32;
+                self.shl(shift)
+            }
+        }
+
+        impl std::ops::Shl<u32> for $SelfT {
+            type Output = $SelfT;
+            fn shl(self, rhs: u32) -> Self {
+                let shift_by = rhs % $BITS;
+                // `goners_mask` has a 1 in the positions which we're
+                // about to shift off the left of the word.
+                let mask: $InnerT = (1 << shift_by) - 1; // correct size, wrong position
+                let goners_mask: $InnerT = mask << ($BITS - shift_by); // correct size+pos
+
+                // Preserve the bits we're about to shift off the
+                // left-hand side.  Although shl() will shift bits
+                // back onto the least-significant end of the value,
+                // the bits shifted there are the previous top bits of
+                // self.bits, but the top bits of self.bits aren't
+                // part of the value of `self`, since `self.bits` has
+                // a width greater than $BITS.
+                let saved = (self.bits & goners_mask) >> ($BITS - shift_by);
+                let bits = ((self.bits << shift_by) | saved) & Self::VALUE_BITS;
+                Self { bits }
+            }
+        }
+    };
+}
+
+/// `Unsigned5Bit` is used as a system configuration value; that is,
+/// an index into F-memory.
+#[derive(Clone, Copy)]
+pub struct Unsigned5Bit {
+    pub(crate) bits: u8,
+}
+
+/// `Unsigned6Bit` is used as an X-register address. That is, the `j`
+/// in `Xj`.
+#[derive(Clone, Copy)]
+pub struct Unsigned6Bit {
+    pub(crate) bits: u8,
+}
+
+/// `Unsigned9Bit` is the value of a "quarter" of the 36-bit TX-2
+/// machine word.  A number of instructions - and in particular the
+/// Exchange Unit - work on the quarters of a word.
+#[derive(Clone, Copy)]
+pub struct Unsigned9Bit {
+    pub(crate) bits: u16,
+}
+
+/// `Unsigned18Bit` is the value of a "half" of the 36-bit TX-2
+/// machine word.  We use this type to hold STUV-memory addresses,
+/// among other things.  Physical memory addresses though are only 17
+/// bits wide.  The remaining bit can be used to "mark" an address
+/// either for tracing (when it's an instruction address) or for
+/// deferred addressing (when it's an operand address).
+#[derive(Clone, Copy)]
+pub struct Unsigned18Bit {
+    pub(crate) bits: u32,
+}
+
+/// `Unsigned36Bit` is the basic machine word of the TX-2.  This is
+/// the width of the registers in the Arithmetic Unit, and it is the
+/// unit on which the Exchange Unit operates when performing memory
+/// fetches or stores.  This is also the width of all instructions.
+#[derive(Clone, Copy)]
+pub struct Unsigned36Bit {
+    pub(crate) bits: u64,
+}
+
+unsigned_ones_complement_impl!(Unsigned5Bit, 5, u8, Signed5Bit);
+unsigned_ones_complement_impl!(Unsigned6Bit, 6, u8, Signed6Bit);
+unsigned_ones_complement_impl!(Unsigned9Bit, 9, u16, Signed9Bit);
+unsigned_ones_complement_impl!(Unsigned18Bit, 18, u32, Signed18Bit);
+unsigned_ones_complement_impl!(Unsigned36Bit, 36, u64, Signed36Bit);
+
+////////////////////////////////////////////////////////////////////////
+// Unsigned5Bit
+////////////////////////////////////////////////////////////////////////
+
+// all the things that always fit into Unsigned5Bit
+// (there are none)
+// all the things that Unsigned5Bit always fits into
+from_self_to_native_type!(Unsigned5Bit, u8 i8 u16 i16 u32 i32 u64 i64 usize);
+// all the things that Unsigned5Bit may not fit into
+// (there are none)
+// all the things that may not fit into Unsigned5Bit
+try_from_native_type_to_self!(Unsigned5Bit, u8, i8 u8 u16 i16 u32 i32 u64 i64 usize);
+
+////////////////////////////////////////////////////////////////////////
+// Unsigned6Bit
+////////////////////////////////////////////////////////////////////////
+
+// all the things that always fit into Unsigned6Bit
+// (there are none)
+// all the things that Unsigned5Bit always fits into
+from_self_to_native_type!(Unsigned6Bit, u8 i8 u16 i16 u32 i32 u64 i64 usize);
+// all the things that Unsigned6Bit may not fit into
+// (there are none)
+// all the things that may not fit into Unsigned6Bit
+try_from_native_type_to_self!(Unsigned6Bit, u8, i8 u8 u16 i16 u32 i32 u64 i64 usize);
+
+////////////////////////////////////////////////////////////////////////
+// Unsigned9Bit
+////////////////////////////////////////////////////////////////////////
+
+// all the things that always fit into Unsigned9Bit
+from_native_type_to_self!(Unsigned9Bit, u8);
+// all the things that Unsigned9Bit always fits into
+from_self_to_native_type!(Unsigned9Bit, u16 i16 u32 i32 u64 i64);
+// all the things that Unsigned9Bit may not fit into
+try_from_self_to_native_type!(Unsigned9Bit, u8 i8);
+// all the things that may not fit into Unsigned9Bit
+try_from_native_type_to_self!(Unsigned9Bit, u16, i8 u16 i16 u32 i32 u64 i64);
+
+impl From<Unsigned5Bit> for Unsigned9Bit {
+    fn from(n: Unsigned5Bit) -> Self {
+        Self {
+            bits: n.bits.into(),
+        }
+    }
+}
+
+////////////////////////////////////////////////////////////////////////
+// Unsigned18Bit
+////////////////////////////////////////////////////////////////////////
+
+// all the things that always fit into Unsigned18Bit
+from_native_type_to_self!(Unsigned18Bit, u8 u16);
+// all the things that Unsigned18Bit always fits into
+from_self_to_native_type!(Unsigned18Bit, u32 i32 u64 i64);
+// all the things Unsigned18Bit may not fit into
+try_from_self_to_native_type!(Unsigned18Bit, u8 i8 u16 i16);
+// all the things that may not fit into Unsigned18Bit
+try_from_native_type_to_self!(Unsigned18Bit, u32, i8 i16 u32 i32 u64 i64);
+
+impl From<Unsigned5Bit> for Unsigned18Bit {
+    fn from(n: Unsigned5Bit) -> Self {
+        Self {
+            bits: n.bits.into(),
+        }
+    }
+}
+
+impl From<Unsigned9Bit> for Unsigned18Bit {
+    fn from(n: Unsigned9Bit) -> Self {
+        Self {
+            bits: n.bits.into(),
+        }
+    }
+}
+
+////////////////////////////////////////////////////////////////////////
+// Unsigned36Bit
+////////////////////////////////////////////////////////////////////////
+
+// all the things that always fit into Unsigned36Bit
+from_native_type_to_self!(Unsigned36Bit, u8 u16 u32);
+// all the things that Unsigned36Bit always fits into
+from_self_to_native_type!(Unsigned36Bit, u64 i64);
+// all the things Unsigned36Bit may not fit into
+try_from_self_to_native_type!(Unsigned36Bit, u8 i8 u16 i16 u32 i32);
+// all the things that may not fit into Unsigned36Bit
+try_from_native_type_to_self!(Unsigned36Bit, u64, i8 i16 i32 u64 i64);
+
+impl TryFrom<Unsigned36Bit> for Unsigned6Bit {
+    type Error = ConversionFailed;
+    fn try_from(n: Unsigned36Bit) -> Result<Self, ConversionFailed> {
+	match u8::try_from(n.bits) {
+	    Ok(n) => {
+		if n > Self::VALUE_BITS {
+		    Err(ConversionFailed::TooLarge)
+		} else {
+		    Ok(Self {
+			bits: n,
+		    })
+		}
+	    }
+	    Err(_) => Err(ConversionFailed::TooLarge),
+	}
+    }
+}
+impl From<Unsigned5Bit> for Unsigned36Bit {
+    fn from(n: Unsigned5Bit) -> Self {
+        Self {
+            bits: n.bits.into(),
+        }
+    }
+}
+
+impl From<Unsigned9Bit> for Unsigned36Bit {
+    fn from(n: Unsigned9Bit) -> Self {
+        Self {
+            bits: n.bits.into(),
+        }
+    }
+}
+
+impl From<Unsigned18Bit> for Unsigned36Bit {
+    fn from(n: Unsigned18Bit) -> Self {
+        Self {
+            bits: n.bits.into(),
+        }
+    }
+}
+
+impl From<Unsigned6Bit> for Unsigned9Bit {
+    fn from(n: Unsigned6Bit) -> Self {
+	Self {
+	    bits: n.bits.into()
+	}
+    }
+}

--- a/base/src/onescomplement/unsigned/tests.rs
+++ b/base/src/onescomplement/unsigned/tests.rs
@@ -1,0 +1,435 @@
+use std::ops::Shl;
+use std::ops::Shr;
+
+use super::{ConversionFailed, Unsigned9Bit};
+
+macro_rules! assert_octal_eq {
+    ($left:expr, $right:expr $(,)?) => {{
+        match (&$left, &$right) {
+            (left_val, right_val) => {
+                if !(*left_val == *right_val) {
+                    panic!(
+                        "Assertion failed: {:>#012o} != {:>#012o}",
+                        left_val, right_val
+                    );
+                }
+            }
+        }
+    }};
+}
+
+#[test]
+fn test_unsigned9bit_max() {
+    assert_eq!(Unsigned9Bit::MAX.bits, 0o777);
+}
+
+#[test]
+fn test_unsigned9bit_min() {
+    assert_eq!(Unsigned9Bit::MIN.bits, 0);
+}
+
+#[test]
+fn test_from_u8() {
+    assert_eq!(Unsigned9Bit::from(0_u8).bits, 0_u16);
+    assert_eq!(Unsigned9Bit::from(1_u8).bits, 1_u16);
+    assert_eq!(Unsigned9Bit::from(0o377_u8).bits, 0o377_u16);
+}
+
+#[test]
+fn test_try_from_unsigned9bit_u8() {
+    assert_eq!(u8::try_from(Unsigned9Bit::from(0_u8)), Ok(0_u8));
+    assert_eq!(u8::try_from(Unsigned9Bit::from(1_u8)), Ok(1_u8));
+    assert_eq!(u8::try_from(Unsigned9Bit::from(0o377_u8)), Ok(0o377_u8));
+    assert_eq!(
+        u8::try_from(Unsigned9Bit {
+            bits: 0b011_111_111_u16
+        }),
+        Ok(0o377_u8)
+    );
+    // Setting the top bit doesn't make these values negative, unlike Signed9Bit.
+    assert_eq!(
+        u8::try_from(Unsigned9Bit {
+            bits: 0b111_111_110_u16
+        }),
+        Err(ConversionFailed::TooLarge)
+    );
+    assert_eq!(
+        u8::try_from(Unsigned9Bit {
+            bits: 0b110_000_000_u16
+        }),
+        Err(ConversionFailed::TooLarge)
+    );
+}
+
+#[test]
+fn test_i8_round_tripping() {
+    let mut prev: Option<Unsigned9Bit> = None;
+    for i in 0..i8::MAX {
+        let q: Unsigned9Bit = Unsigned9Bit::try_from(i).unwrap();
+        if let Some(qprev) = prev {
+            assert!(
+                q > qprev,
+                "failed to round-trip {}: {:?} should be greater than {:?}",
+                i,
+                q,
+                qprev
+            );
+        }
+        prev = Some(q);
+        match i8::try_from(q) {
+            Ok(out) => {
+                assert_eq!(i, out, "Round trip failed for {}->{:?}->{}", i, &q, out);
+            }
+            Err(e) => {
+                panic!(
+		    "Unexpected overflow when round-tripping  {}->{:?}-> [conversion to i8 failed with error {}]",
+		    i, &q, e);
+            }
+        }
+    }
+}
+
+#[test]
+fn test_u8_round_tripping() {
+    let mut prev: Option<Unsigned9Bit> = None;
+    for i in u8::MIN..u8::MAX {
+        let q: Unsigned9Bit = Unsigned9Bit::from(i);
+        if let Some(qprev) = prev {
+            assert!(
+                q > qprev,
+                "failed to round-trip {}: {:?} should be greater than {:?}",
+                i,
+                q,
+                qprev
+            );
+        }
+        prev = Some(q);
+        match u8::try_from(q) {
+            Ok(out) => {
+                assert_eq!(i, out, "Round trip failed for {}->{:?}->{}", i, &q, out);
+            }
+            Err(e) => {
+                panic!(
+		    "Unexpected overflow when round-tripping  {}->{:?}-> [conversion to i8 failed with error {}]",
+		    i, &q, e);
+            }
+        }
+    }
+}
+
+#[test]
+fn test_try_from_i8_unsigned9bit() {
+    assert_octal_eq!(Unsigned9Bit::try_from(0_i8).unwrap().bits, 0_u16);
+    assert_octal_eq!(Unsigned9Bit::try_from(1_i8).unwrap().bits, 1_u16);
+    assert_octal_eq!(Unsigned9Bit::try_from(127_i8).unwrap().bits, 127_u16);
+
+    assert_eq!(
+        Unsigned9Bit::try_from(-1_i8),
+        Err(ConversionFailed::TooSmall)
+    );
+    assert_eq!(
+        Unsigned9Bit::try_from(-2_i8),
+        Err(ConversionFailed::TooSmall)
+    );
+    assert_eq!(
+        Unsigned9Bit::try_from(-8_i8),
+        Err(ConversionFailed::TooSmall)
+    );
+    assert_eq!(
+        Unsigned9Bit::try_from(-128_i8),
+        Err(ConversionFailed::TooSmall)
+    );
+}
+
+#[test]
+fn test_unsigned9bit_zero_values() {
+    const ZERO: Unsigned9Bit = Unsigned9Bit { bits: 0_u16 };
+    assert_eq!(u16::from(ZERO), 0, "zero should convert to 0_u16");
+    assert_eq!(u8::try_from(ZERO), Ok(0), "zero should convert to 0_u8");
+
+    // The value that would be +0 in Signed9Bit is just a large value in Unsigned9Bit.
+    const CAREFUL_NOW: Unsigned9Bit = Unsigned9Bit {
+        bits: 0b111_111_111_u16,
+    };
+    assert_eq!(u16::try_from(CAREFUL_NOW), Ok(0o777));
+}
+
+#[test]
+fn test_from_unsigned9bit_to_i8() {
+    assert_eq!(i8::try_from(Unsigned9Bit { bits: 0 }), Ok(0_i8));
+    assert_eq!(i8::try_from(Unsigned9Bit { bits: 1 }), Ok(1_i8));
+    assert_eq!(i8::try_from(Unsigned9Bit { bits: 127_u16 }), Ok(127_i8));
+    assert_eq!(
+        i8::try_from(Unsigned9Bit {
+            bits: 0b111_111_110_u16
+        }),
+        Err(ConversionFailed::TooLarge)
+    );
+    assert_eq!(
+        i8::try_from(Unsigned9Bit {
+            bits: 0b111_111_101_u16
+        }),
+        Err(ConversionFailed::TooLarge)
+    );
+    assert_eq!(
+        i8::try_from(Unsigned9Bit {
+            bits: 0b110_111_101_u16
+        }),
+        Err(ConversionFailed::TooLarge)
+    );
+    assert_eq!(
+        i8::try_from(Unsigned9Bit {
+            bits: 0b110_000_000_u16
+        }),
+        Err(ConversionFailed::TooLarge)
+    );
+    assert!(i8::try_from(Unsigned9Bit::MAX).is_err());
+    assert_eq!(i8::try_from(Unsigned9Bit::MIN), Ok(0));
+}
+
+#[test]
+fn test_from_u16_to_unsigned9bit() {
+    assert_octal_eq!(Unsigned9Bit::try_from(0_u16).unwrap().bits, 0_u16);
+    assert_octal_eq!(Unsigned9Bit::try_from(1_u16).unwrap().bits, 1_u16);
+    assert_octal_eq!(Unsigned9Bit::try_from(0o377_u16).unwrap().bits, 0o377_u16);
+    assert_octal_eq!(Unsigned9Bit::try_from(0o400_u16).unwrap().bits, 0o400);
+    assert_eq!(
+        Unsigned9Bit::try_from(0o1000_u16),
+        Err(ConversionFailed::TooLarge)
+    );
+}
+
+#[test]
+fn test_from_unsigned9bit_to_u16() {
+    assert_octal_eq!(u16::from(Unsigned9Bit { bits: 0 }), 0);
+    assert_octal_eq!(u16::from(Unsigned9Bit { bits: 1 }), 1);
+    assert_octal_eq!(u16::from(Unsigned9Bit { bits: 0o377_u16 }), 0o377_u16);
+    assert_octal_eq!(u16::from(Unsigned9Bit { bits: 0o400_u16 }), 0o400_u16);
+    assert_octal_eq!(u16::from(Unsigned9Bit { bits: 0o477_u16 }), 0o477_u16);
+    assert_octal_eq!(u16::from(Unsigned9Bit { bits: 0o777_u16 }), 0o777_u16);
+}
+
+#[test]
+fn test_unsigned9bit_ord() {
+    let zero: Unsigned9Bit = Unsigned9Bit::from(0_u8);
+    let one: Unsigned9Bit = Unsigned9Bit::from(1_u8);
+    assert!(zero < one);
+    assert!(!(one < zero));
+    assert!(!(zero < zero));
+    assert!(!(one < one));
+
+    assert!(one > zero);
+    assert!(!(zero > zero));
+    assert!(!(one > one));
+    assert!(!(zero > one));
+
+    assert!(Unsigned9Bit::MIN < Unsigned9Bit::MAX);
+    assert!(Unsigned9Bit::MAX > Unsigned9Bit::MIN);
+}
+
+#[test]
+fn test_unsigned9bit_eq() {
+    let zero: Unsigned9Bit = Unsigned9Bit::from(0_u8);
+    let one: Unsigned9Bit = Unsigned9Bit::from(1_u8);
+    assert_eq!(zero, zero);
+    assert_eq!(one, one);
+
+    let another_one: Unsigned9Bit = Unsigned9Bit::from(1_u8);
+    assert_eq!(
+        one, another_one,
+        "ensure we don't confuse identy with equality"
+    );
+}
+
+#[test]
+fn test_unsigned9bit_checked_add() {
+    let zero: Unsigned9Bit = Unsigned9Bit::from(0_u8);
+    let one: Unsigned9Bit = Unsigned9Bit::from(1_u8);
+
+    // Test the basics: adding zero to something leaves it unchanged.
+    assert_eq!(zero.checked_add(zero), Some(zero));
+    assert_eq!(zero.checked_add(one), Some(one));
+    assert_eq!(one.checked_add(zero), Some(one));
+    assert_eq!(Unsigned9Bit::MAX.checked_add(zero), Some(Unsigned9Bit::MAX));
+    assert_eq!(Unsigned9Bit::MIN.checked_add(zero), Some(Unsigned9Bit::MIN));
+
+    // Test the basics: 1+1=2
+    let two: Unsigned9Bit = Unsigned9Bit::from(2_u8);
+    assert_eq!(one.checked_add(one), Some(two));
+
+    // Verify that we correctly detect overflow
+    assert_eq!(Unsigned9Bit::MAX.checked_add(one), None);
+}
+
+#[test]
+fn test_unsigned9bit_checked_sub() {
+    let zero: Unsigned9Bit = Unsigned9Bit::from(0_u8);
+    let one: Unsigned9Bit = Unsigned9Bit::from(1_u8);
+
+    // Test the basics: adding zero to something leaves it unchanged.
+    assert_eq!(zero.checked_sub(zero), Some(zero));
+    assert_eq!(one.checked_sub(zero), Some(one));
+    assert_eq!(Unsigned9Bit::MAX.checked_sub(zero), Some(Unsigned9Bit::MAX));
+    assert_eq!(Unsigned9Bit::MIN.checked_sub(zero), Some(Unsigned9Bit::MIN));
+
+    // Test the basics: 2-1=1
+    let two: Unsigned9Bit = Unsigned9Bit::from(2_u8);
+    assert_eq!(two.checked_sub(one), Some(one));
+    assert_eq!(two.checked_sub(two), Some(zero));
+
+    // Verify that we correctly detect overflow
+    assert_eq!(Unsigned9Bit::MIN.checked_sub(one), None);
+    assert_eq!(zero.checked_sub(one), None); // same thing
+
+    assert_eq!(
+        u16::from(Unsigned9Bit::MAX.checked_sub(one).unwrap()),
+        510_u16
+    );
+}
+
+#[test]
+fn test_unsigned9bit_abs() {
+    let zero: Unsigned9Bit = Unsigned9Bit::from(0_u8);
+    let one: Unsigned9Bit = Unsigned9Bit::from(1_u8);
+    assert_eq!(zero, zero.abs());
+    assert_eq!(one, one.abs());
+}
+
+#[test]
+fn test_unsigned9bit_checked_abs() {
+    let zero: Unsigned9Bit = Unsigned9Bit::from(0_u8);
+    let one: Unsigned9Bit = Unsigned9Bit::from(1_u8);
+    assert_eq!((zero, false), zero.overflowing_abs());
+    assert_eq!((one, false), one.overflowing_abs());
+}
+
+#[test]
+fn test_unsigned9bit_not() {
+    let all_zeroes = Unsigned9Bit { bits: 0 };
+    let all_ones = Unsigned9Bit { bits: 0o777 };
+    assert_eq!(!all_zeroes, all_ones);
+    assert_eq!(!all_ones, all_zeroes);
+
+    assert_eq!(!Unsigned9Bit { bits: 1 }, Unsigned9Bit { bits: 0o776 });
+    assert_eq!(!Unsigned9Bit { bits: 0o40 }, Unsigned9Bit { bits: 0o737 });
+}
+
+#[test]
+fn test_unsigned9bit_and() {
+    let all_zeroes = Unsigned9Bit { bits: 0 };
+    let all_ones = Unsigned9Bit { bits: 0o777 };
+    assert_eq!(all_zeroes & all_zeroes, all_zeroes);
+    assert_eq!(all_ones & all_ones, all_ones);
+    assert_eq!(all_ones & all_zeroes, all_zeroes);
+
+    let three = Unsigned9Bit { bits: 0o3 };
+    let two = Unsigned9Bit { bits: 0o2 };
+    assert_eq!(three & two, two);
+}
+
+#[test]
+fn test_unsigned9bit_impl_and() {
+    let all_zeroes = Unsigned9Bit { bits: 0 };
+    let all_ones = Unsigned9Bit { bits: 0o777 };
+    assert_eq!(all_zeroes.and(0_u16), all_zeroes);
+    assert_eq!(all_ones.and(0o777_u16), all_ones);
+    assert_eq!(all_ones.and(0_u16), all_zeroes);
+
+    let three = Unsigned9Bit { bits: 0o3 };
+    let two = Unsigned9Bit { bits: 0o2 };
+    assert_eq!(three & 0o2_u16, two);
+}
+
+#[test]
+fn test_unsigned9bit_or() {
+    let all_zeroes = Unsigned9Bit { bits: 0 };
+    let all_ones = Unsigned9Bit { bits: 0o777 };
+    assert_eq!(all_zeroes & all_zeroes, all_zeroes);
+    assert_eq!(all_ones | all_ones, all_ones);
+    assert_eq!(all_ones | all_zeroes, all_ones);
+
+    let three = Unsigned9Bit { bits: 0o3 };
+    let two = Unsigned9Bit { bits: 0o2 };
+    assert_eq!(three | two, three);
+    assert_eq!(three | all_zeroes, three);
+    assert_eq!(three | all_ones, all_ones);
+}
+
+#[test]
+fn test_unsigned9bit_shr() {
+    let zero: Unsigned9Bit = Unsigned9Bit::from(0_u8);
+    let one: Unsigned9Bit = Unsigned9Bit::from(1_u8);
+    assert_eq!(zero.shr(zero), zero);
+    assert_eq!(zero.shr(one), zero);
+    assert_eq!(one.shr(zero), one);
+
+    // Shifting the least significant bit off the right-hand side puts
+    // it into the most-signficant position.
+    assert_eq!(one.shr(one), Unsigned9Bit::ZERO | (1_u16 << 8));
+
+    // If we shift a bit more places to the right than there are bit
+    // positions, it just ends up in the position determined by the
+    // obvious modulus operation (and e.g. does not get zeroed).
+    //
+    // Shift right by   ... is equivalent to shifting right by
+    //              9                                        0
+    //             10                                        1
+    //             11                                        2
+    //             12                                        3
+    //             13                                        4
+    // ...
+    //             31                                        4
+    assert_eq!(one.shr(Unsigned9Bit::from(9_u8)), one);
+    assert_eq!(
+        one.shr(Unsigned9Bit::from(10_u8)),
+        Unsigned9Bit::try_from(0o400).unwrap()
+    );
+    assert_eq!(
+        one.shr(Unsigned9Bit::from(11_u8)),
+        Unsigned9Bit::try_from(0o200).unwrap()
+    );
+    assert_eq!(
+        one.shr(Unsigned9Bit::from(12_u8)),
+        Unsigned9Bit::try_from(0o100).unwrap()
+    );
+    assert_eq!(
+        one.shr(Unsigned9Bit::from(13_u8)),
+        Unsigned9Bit::try_from(0o040).unwrap()
+    );
+    assert_eq!(
+        one.shr(Unsigned9Bit::from(31_u8)),
+        Unsigned9Bit::try_from(0o040).unwrap()
+    );
+
+    let all_ones = Unsigned9Bit { bits: 0o777 };
+    assert_eq!(all_ones.shr(zero), all_ones);
+    assert_eq!(all_ones.shr(one), all_ones);
+    assert_eq!(all_ones.shr(all_ones), all_ones);
+}
+
+#[test]
+fn test_unsigned9bit_shl() {
+    let zero: Unsigned9Bit = Unsigned9Bit::from(0_u8);
+    let one: Unsigned9Bit = Unsigned9Bit::from(1_u8);
+    assert_eq!(zero.shl(zero), zero);
+    assert_eq!(zero.shl(one), zero);
+    assert_eq!(one.shl(zero), one);
+
+    let two: Unsigned9Bit = Unsigned9Bit::from(2_u8);
+    assert_eq!(one.shl(one), two);
+
+    assert_octal_eq!(
+        Unsigned9Bit::try_from(0o400).unwrap().shl(1),
+        Unsigned9Bit::from(1_u8)
+    );
+
+    assert_octal_eq!(
+        Unsigned9Bit::try_from(0o020).unwrap().shl(14),
+        Unsigned9Bit::from(1_u8)
+    );
+
+    assert_eq!(Unsigned9Bit::ZERO, Unsigned9Bit::ZERO << Unsigned9Bit::ZERO);
+    assert_eq!(Unsigned9Bit::ZERO, Unsigned9Bit::ZERO << Unsigned9Bit::ONE);
+    assert_eq!(Unsigned9Bit::ONE, Unsigned9Bit::ONE << Unsigned9Bit::ZERO);
+    assert_eq!(Unsigned9Bit::from(4_u8), Unsigned9Bit::ONE << Unsigned9Bit::from(2_u8));
+}

--- a/base/src/prelude.rs
+++ b/base/src/prelude.rs
@@ -1,0 +1,10 @@
+//! The prelude exports a number of structs which are useful in
+//! representing things to do with the TX-2.  Providing this prelude
+//! is the main purpose of the base crate.
+pub use crate::instruction::*;
+pub use crate::onescomplement::signed::*;
+pub use crate::onescomplement::unsigned::*;
+pub use crate::subword::join_halves;
+pub use crate::subword::join_quarters;
+pub use crate::types::IndexBy;
+pub use crate::types::*;

--- a/base/src/subword.rs
+++ b/base/src/subword.rs
@@ -1,0 +1,110 @@
+//! Various convenience utilities for splitting 36-bit TX-2 words
+//! into smaller components and for joining them together.
+use std::ops::Shl;
+
+use crate::onescomplement::unsigned::{Unsigned18Bit, Unsigned36Bit, Unsigned9Bit};
+
+/// Split a 36-bit word into two 18-bit values.
+pub fn split_halves(w: Unsigned36Bit) -> (Unsigned18Bit, Unsigned18Bit) {
+    (left_half(w), right_half(w))
+}
+
+/// Join two 18-bit values into a 36-bit word.
+pub fn join_halves(left: Unsigned18Bit, right: Unsigned18Bit) -> Unsigned36Bit {
+    Unsigned36Bit::from(left).shl(18) | Unsigned36Bit::from(right)
+}
+
+/// Join two quarters into a halfword.
+pub fn join_quarters(left: Unsigned9Bit, right: Unsigned9Bit) -> Unsigned18Bit {
+    Unsigned18Bit::from(left).shl(9) | Unsigned18Bit::from(right)
+}
+
+/// Extract the right (more-significant) halfword from a full word.
+pub fn right_half(word: Unsigned36Bit) -> Unsigned18Bit {
+    let bits: u64 = u64::from(word);
+    Unsigned18Bit::try_from(bits & 0o777_777).unwrap()
+}
+
+/// Extract the right (less-significant) halfword from a full word.
+pub fn left_half(word: Unsigned36Bit) -> Unsigned18Bit {
+    let bits: u64 = u64::from(word) >> 18;
+    Unsigned18Bit::try_from(bits & 0o777_777).unwrap()
+}
+
+/// Split a halfword into left (more significant) and right (less
+/// significant) 9-bit quarters (in the sense that they are quarters
+/// of the original 26-bit full word).
+pub fn split_halfword(halfword: Unsigned18Bit) -> (Unsigned9Bit, Unsigned9Bit) {
+    let bits: u32 = u32::from(halfword);
+    (Unsigned9Bit::try_from((bits >> 9) & 0o777).unwrap(),
+     Unsigned9Bit::try_from((bits     ) & 0o777).unwrap())
+}
+
+/// Split a 36-bit word into four 9-bit quarters.  The result is a
+/// tuple which contains the quarters ordered from most-significant
+/// (Q4) to least-significant (Q1).
+pub fn quarters(word: Unsigned36Bit) -> [Unsigned9Bit; 4] {
+    let (left, right) = split_halves(word);
+    let (q4, q3) = split_halfword(left);
+    let (q2, q1) = split_halfword(right);
+    [q4, q3, q2, q1]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::onescomplement::unsigned::{Unsigned18Bit, Unsigned36Bit, Unsigned9Bit};
+
+    macro_rules! assert_octal_eq {
+        ($left:expr, $right:expr $(,)?) => {{
+            match (&$left, &$right) {
+                (left_val, right_val) => {
+                    if !(*left_val == *right_val) {
+                        panic!(
+                            "Assertion failed: {:>#012o} != {:>#012o}",
+                            left_val, right_val
+                        );
+                    }
+                }
+            }
+        }};
+    }
+
+    #[test]
+    fn test_join_halves() {
+        assert_octal_eq!(
+            join_halves(
+                Unsigned18Bit::try_from(0o123_456_u32).unwrap(),
+                Unsigned18Bit::try_from(0o525_252_u32).unwrap()
+            ),
+            Unsigned36Bit::try_from(0o123_456_525_252_u64).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_join_quarters() {
+        assert_octal_eq!(
+            join_quarters(
+                Unsigned9Bit::try_from(0o123_u16).unwrap(),
+                Unsigned9Bit::try_from(0o456_u16).unwrap()
+            ),
+            Unsigned18Bit::try_from(0o123_456_u32).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_split_halfword() {
+        let h = Unsigned18Bit::try_from(0o123_456_u32).expect("valid test data");
+	assert_eq!(split_halfword(h), (Unsigned9Bit::try_from(0o123).unwrap(),
+				       Unsigned9Bit::try_from(0o456).unwrap()));
+    }
+
+    #[test]
+    fn test_quarters() {
+	fn q(n: u16) -> Unsigned9Bit {
+	    Unsigned9Bit::try_from(n).expect("valid test data")
+	}
+	assert_eq!(quarters(Unsigned36Bit::try_from(0o123_456_525_252_u64).unwrap()),
+		   [q(0o123), q(0o456), q(0o525), q(0o252)])
+    }
+}

--- a/base/src/types.rs
+++ b/base/src/types.rs
@@ -1,0 +1,307 @@
+/// The TX-2 uses 36-bit words.  We use Unsigned36Bit (defined in
+/// onescomplement/unsigned.rs) to represent this.  As stored in
+/// memory, there are two additional bits; these are implemented in
+/// the CPU emulation, not here.
+
+use std::cmp::Ordering;
+use std::fmt::{Debug, Display, Error, Formatter, Octal};
+
+use crate::onescomplement::error::ConversionFailed;
+use crate::onescomplement::signed::{
+    Signed5Bit,
+    Signed6Bit,
+    Signed18Bit,
+};
+use crate::onescomplement::unsigned::{
+    Unsigned18Bit,
+    Unsigned36Bit,
+    Unsigned6Bit,
+};
+use crate::onescomplement::{Sign, WordCommon};
+
+/// The `IndexBy` trait implements address arithmetic (adding a signed
+/// or unsigned value to an address).
+///
+/// On page 12-9, Volume 2 of the Technical Manual contains some
+/// wording that I interpret to mean that address indexation arithmetic
+/// wraps:
+///
+/// > While the sum of a base address in N₂,₁ and an index register in
+/// > X is being formed betweek PK¹³ and PK²², the X Adder carry
+/// > circuit is forced into a "set" condition.  This causes the sum
+/// > of an 18 bit number and its 18 bit ONE's complement to be all
+/// > ZEROS, rather than all ONES, if this sum should be formed.  The
+/// > comuted address of an operand, deferred address, or next
+/// > instruction then becomes the first register of the S Memory
+/// > (address 0) rather than the last register of the V mMemory
+/// > (address 377 777 (octal)), when, for example, the base address
+/// > is 000 004 and the index is 777 773.  The logic for obtaining
+/// > this result simply uses the PK¹³ᵝ 0.4 microsecond time level to
+/// > set the X Adder carry circuit at the time that XAC would
+/// > ordinarily have been used to clear it.
+///
+/// IndexBy is also used to increment the program counter, and on the
+/// real TX2 this was done by a special circuit, not an adder.
+/// Volume 2 of the Technical Manual (section 12-2.3 "P REGISTER
+/// DRIVER LOGIC") states,
+///
+/// > Information can be transferred into the P register only from the
+/// > X Adder.  In addition to this single transfer path, ther P
+/// > register has a counter which can index the contents of the P
+/// > register by one.  Note that count circuit does not alter the
+/// > contents of P₂.₉
+pub trait IndexBy<T> {
+    fn index_by(&self, delta: T) -> Address;
+}
+
+/// An address has 17 normal value bits.  There are 18 bits for the
+/// operand base address in the instruction word, but the topmost bit
+/// signals a deferred (i.e. indirect) access, so we should never see
+/// a memory access to an address with the 0o400_000 bit set.
+///
+/// The program counter can also have its top bit set.  This signals
+/// that in the TX-2 hardware, the associated sequence should be
+/// traced via Trap 42.
+///
+/// The Xj (index) registers form an 18-bit ring and are described on
+/// page 3-68 of the User Handbook (section 3-3.1) as being signed
+/// integers.  Yet P (which also holds an address) is described on the
+/// same page as being a positive integer.  Therefore when performing
+/// address arithmetic, we sometimes need to convert index register
+/// values to the [`Signed18Bit`] type.
+#[derive(Clone, Copy)]
+pub struct Address(Unsigned18Bit);
+
+/// Placeholders (saved sequence instruction pointers in the index
+/// registers) use bit 2.9 to indicate that sequence switches to
+/// marked sequences should trap to sequence 42.  This means that the
+/// mark bit needs to be retained in the program counter (P register)
+/// so that the sequence is still "marked" after it has run.
+pub const PLACEHOLDER_MARK_BIT: Unsigned18Bit = Unsigned18Bit::MAX.and(1u32 << 17); // bit 2.9
+
+impl Address {
+    pub const ZERO: Address = Address(Unsigned18Bit::ZERO);
+    pub const MAX: Address = Address(Unsigned18Bit::MAX);
+
+    /// Apply a bitmask to an address.  This could also be done via
+    /// [`std::ops::BitAnd`], but trait implementations cannot be
+    /// const.  Implementing this const methods allows us to form
+    /// address constants at compile time with code like `Address::MAX
+    /// & 0o03400`.
+    pub const fn and(&self, mask: u32) -> Address {
+        Address(self.0.and(mask)) // use same hack in Unsigned18Bit.
+    }
+
+    /// Extract the placeholder mark bit.
+    pub fn mark_bit(&self) -> Unsigned18Bit {
+        self.0 & PLACEHOLDER_MARK_BIT
+    }
+
+    /// The placeholder phrasing here comes from the "TRAP 42"
+    /// features.  But the high bit in the operand address field in an
+    /// instruction also marks the operand as using deferred
+    /// addressing.  We should choose more neutral naming to avoid
+    /// confusion.
+    pub fn is_marked_placeholder(&self) -> bool {
+        self.0 & PLACEHOLDER_MARK_BIT != 0_u16
+    }
+
+    /// Split an address into its bottom 17 bits (which corresponds to
+    /// an actual memory register on the TX-2) and a "mark" bit.  The
+    /// "mark" bit is variously used to signal deferred addressing
+    /// when fetching operands, and to flag a sequence for tracing
+    /// with trap 42 (in this context is is called a "placeholder mark
+    /// bit").  The `split` method is the opposite of `join`.
+    pub fn split(&self) -> (Unsigned18Bit, bool) {
+        let without_mark: Unsigned18Bit = self.0 & !PLACEHOLDER_MARK_BIT;
+        (without_mark, self.is_marked_placeholder())
+    }
+
+    /// Form an address from the bottom 17 bits of `addr` and a
+    /// possilbe mark bit, `mark`.  If `mark` is false, the resulting
+    /// address will have a zero-valued top bit, no matter what is in
+    /// `addr`.  This is the opposite of `split`.
+    pub fn join(addr: Unsigned18Bit, mark: bool) -> Address {
+	let markbit: Unsigned18Bit = if mark { PLACEHOLDER_MARK_BIT } else { Unsigned18Bit::ZERO };
+	let addr_without_mark: Unsigned18Bit = addr & !PLACEHOLDER_MARK_BIT;
+	Address::from(markbit | addr_without_mark)
+    }
+
+    /// Computes the address following the current address.  Used,
+    /// among other things, to increment the program counter.
+    ///
+    /// The simulator relies on the fact that (as in the hardware TX-2
+    /// P register) this calculation will wrap from 0o377_777 to 0.
+    pub fn successor(&self) -> Address {
+        self.index_by(1_u8)
+    }
+}
+
+impl From<Unsigned18Bit> for Address {
+    fn from(a: Unsigned18Bit) -> Address {
+        Address(a)
+    }
+}
+
+impl From<Address> for Unsigned18Bit {
+    fn from(addr: Address) -> Self {
+        addr.0
+    }
+}
+
+impl From<Address> for Unsigned36Bit {
+    fn from(addr: Address) -> Self {
+        Unsigned36Bit::from(u32::from(addr))
+    }
+}
+
+impl IndexBy<u8> for Address {
+    fn index_by(&self, index: u8) -> Address {
+        let offset: Unsigned18Bit = index.into();
+        let (address, mark) = self.split();
+	Address::join(address.wrapping_add(offset) & !PLACEHOLDER_MARK_BIT, mark)
+    }
+}
+
+fn idx_impl(base: Address, delta: Signed18Bit) -> Result<Address, ConversionFailed> {
+    let (current, mark) = base.split();
+    let abs_delta: Unsigned18Bit = Unsigned18Bit::try_from(i32::from(delta.abs()))?;
+    let physical = match delta.signum() {
+        Sign::Zero => current,
+        Sign::Positive => current.wrapping_add(abs_delta),
+        Sign::Negative => current.wrapping_sub(abs_delta),
+    } & !PLACEHOLDER_MARK_BIT;
+    Ok(Address::join(physical, mark))
+}
+
+impl IndexBy<Signed5Bit> for Address {
+    fn index_by(&self, delta: Signed5Bit) -> Address {
+	idx_impl(*self, Signed18Bit::from(delta)).unwrap()
+    }
+}
+
+impl IndexBy<Signed6Bit> for Address {
+    fn index_by(&self, delta: Signed6Bit) -> Address {
+	idx_impl(*self, Signed18Bit::from(delta)).unwrap()
+    }
+}
+
+impl IndexBy<Signed18Bit> for Address {
+    fn index_by(&self, delta: Signed18Bit) -> Address {
+	idx_impl(*self, delta).unwrap()
+    }
+}
+
+#[test]
+fn index_by_5bit_quantity() {
+    let start: Address = Address::from(Unsigned18Bit::from(0o4000_u16));
+    let up: Signed5Bit = Signed5Bit::try_from(6_i8).unwrap();
+    assert_eq!(
+        start.index_by(up),
+        Address::from(Unsigned18Bit::from(0o4006_u16))
+    );
+
+    let down: Signed5Bit = Signed5Bit::try_from(-4_i8).unwrap();
+    assert_eq!(
+        start.index_by(down),
+        Address::from(Unsigned18Bit::from(0o3774_u16))
+    );
+}
+
+impl TryFrom<u32> for Address {
+    type Error = ConversionFailed;
+    fn try_from(n: u32) -> Result<Address, ConversionFailed> {
+        let value = Unsigned18Bit::try_from(n)?;
+        Ok(Address::from(value))
+    }
+}
+
+impl From<Address> for u32 {
+    fn from(a: Address) -> u32 {
+        u32::from(Unsigned18Bit::from(a))
+    }
+}
+
+impl From<&Address> for u32 {
+    fn from(a: &Address) -> u32 {
+        u32::from(Unsigned18Bit::from(*a))
+    }
+}
+
+impl Default for Address {
+    fn default() -> Address {
+        Address::from(Unsigned18Bit::from(0_u8))
+    }
+}
+
+impl Display for Address {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
+        // Always display as octal.
+        write!(f, "{:>08o}", self.0)
+    }
+}
+
+impl Octal for Address {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
+        let val = self.0;
+        Octal::fmt(&val, f) // delegate to u32's implementation
+    }
+}
+
+impl Debug for Address {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
+        // Always display as octal.
+        write!(f, "{:>08o}", self.0)
+    }
+}
+
+impl Ord for Address {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.0.cmp(&other.0)
+    }
+}
+
+impl PartialOrd for Address {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl PartialEq for Address {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.eq(&other.0)
+    }
+}
+
+impl PartialEq<u32> for Address {
+    fn eq(&self, other: &u32) -> bool {
+        let v: u32 = self.0.into();
+        v.eq(other)
+    }
+}
+impl Eq for Address {}
+
+pub type SequenceNumber = Unsigned6Bit;
+
+#[test]
+fn test_sequence_numnber() {
+    const ZERO: SequenceNumber = SequenceNumber::ZERO;
+    const ONE: SequenceNumber = SequenceNumber::ONE;
+
+    // Verify that left-shift works (becauise we will need it when
+    // handling flag raise/lower operations).
+    assert_eq!(SequenceNumber::try_from(2_u8).unwrap(), ONE << ONE);
+
+    // Verify that comparisons work (because we will need those when
+    // figuring out whether a raised flag should cause a sequence
+    // change).
+    assert!(ONE > ZERO);
+    assert!(ZERO < ONE);
+    assert_eq!(ONE, ONE);
+    assert_eq!(ZERO, ZERO);
+    assert!(!(ONE == ZERO));
+    assert!(!(ZERO == ONE));
+
+    // When SequenceNumber is Unsigned6Bit, SequenceNumber::MAX should be 0o77.
+    // assert_eq!(SequenceNumber::MAX, SequenceNumber::try_from(0o77_u8).unwrap());
+}


### PR DESCRIPTION
There's no actual simulation happening here in this PR, but this code defines the basic types which would be used to represent data inside a simulator (or, for that matter, inside an assembler).