### PR TITLE
Merge jy/add cpu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/target
+Cargo.lock
+*~

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,7 @@ members = [
 	# be shared for example between the emulator and a
 	# cross-assembler).
 	"base",
+
+	# cpu implements the cpu emulation itself.
+	"cpu",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,7 @@ members = [
 
 	# cpu implements the cpu emulation itself.
 	"cpu",
+
+	# cli provides a basic emulator suitable for running from the command-line.
+	"cli",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,8 @@
+[workspace]
+
+members = [
+	# base includes a representation for instructions (which could
+	# be shared for example between the emulator and a
+	# cross-assembler).
+	"base",
+]

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2021 The TX-2 Simulator Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/base/Cargo.toml
+++ b/base/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "base"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/base/src/instruction/format.rs
+++ b/base/src/instruction/format.rs
@@ -1,0 +1,490 @@
+/// Human-oriented formatting for instructions (or parts of instructions).
+use std::fmt::{self, Display, Formatter, Octal};
+use std::error::Error;
+
+use crate::prelude::*;
+use crate::instruction::{
+    Quarter,
+    BitSelector,
+    DisassemblyFailure,
+    index_address_to_bit_selection,
+    Inst,
+    Opcode,
+    OperandAddress,
+    SymbolicInstruction,
+};
+
+/// Render the quarter ("q") part of the bit selector ("q.b").
+impl Display for Quarter {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+	f.write_str(match self {
+	    Quarter::Q1 => "1",
+	    Quarter::Q2 => "2",
+	    Quarter::Q3 => "3",
+	    Quarter::Q4 => "4",
+	})
+    }
+}
+
+/// Render the bit selector in the form q.b.  Unfortunately the TX2
+/// documentation is inconsistent in how the bit number is formatted.
+/// Page 3-34 of the User Handbook clearly says "Bit Numbers are
+/// interpreted asd Decimal".  However, the plugboard listing (page
+/// 5-27 of the same document) disassembles the instruction 301712
+/// 377744 as "³⁰SKN₄.₁₂ 377744" so here the bit number is given in
+/// octal.  We adopt the decimal convention since it is in wider use
+/// in the documentation.
+impl Display for BitSelector {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+	write!(f, "{}.{}", self.quarter, self.bitpos)
+    }
+}
+
+/// Convert an opcode to its text representation.
+///
+/// The primary (i.e. not supernumerary) opcode mnemonic is used,
+/// because the configuration value which would identify a
+/// supernumerary opcode is not passed to the `fmt` method of the
+/// `Display` trait.
+impl Display for Opcode {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+        use Opcode::*;
+        f.write_str(match self {
+            Ios => "IOS",
+            Jmp => "JMP",
+            Jpx => "JPX",
+            Jnx => "JNX",
+            Aux => "AUX",
+            Rsx => "RSX",
+            Skx => "SKX",
+            Exx => "EXX",
+            Adx => "ADX",
+            Dpx => "DPX",
+            Skm => "SKM",
+            Lde => "LDE",
+            Spf => "SPF",
+            Spg => "SPG",
+            Lda => "LDA",
+            Ldb => "LDB",
+            Ldc => "LDC",
+            Ldd => "LDD",
+            Ste => "STE",
+            Flf => "FLF",
+            Flg => "FLG",
+            Sta => "STA",
+            Stb => "STB",
+            Stc => "STC",
+            Std => "STD",
+            Ite => "ITE",
+            Ita => "ITA",
+            Una => "UNA",
+            Sed => "SED",
+            Jov => "JOV",
+            Jpa => "JPA",
+            Jna => "JNA",
+            Exa => "EXA",
+            Ins => "INS",
+            Com => "COM",
+            Tsd => "TSD",
+            Cya => "CYA",
+            Cyb => "CYB",
+            Cab => "CAB",
+            Noa => "NOA",
+            Dsa => "DSA",
+            Nab => "NAB",
+            Add => "ADD",
+            Sca => "SCA",
+            Scb => "SCB",
+            Sab => "SAB",
+            Tly => "TLY",
+            Div => "DIV",
+            Mul => "MUL",
+            Sub => "SUB",
+        })
+    }
+}
+
+/// Format an operand address in octal.
+///
+/// Deferred addresses are formatted in square brackets.  TX-2
+/// documentation seems variously to represent deferred addressing
+/// with `[...]` or `*`.  We use `[...]`.
+impl Octal for OperandAddress {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+        match self {
+            OperandAddress::Direct(addr) => {
+                write!(f, "{:o}", addr)
+            }
+            OperandAddress::Deferred(addr) => {
+                write!(f, "[{:o}]", addr)
+            }
+        }
+    }
+}
+
+impl Display for DisassemblyFailure {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+        let opcode = match self {
+            DisassemblyFailure::InvalidOpcode(n) => {
+                f.write_str("invalid opcode")?;
+                n
+            }
+            DisassemblyFailure::UnimplementedOpcode(n) => {
+                f.write_str("unimplemented opcode")?;
+                n
+            }
+        };
+        write!(f, " {:03o}", opcode)
+    }
+}
+
+fn superscript_digit(regular_digit: char) -> char {
+    match regular_digit {
+        '0' => '\u{2070}',
+        '1' => '\u{00B9}',
+        '2' => '\u{00B2}',
+        '3' => '\u{00B3}',
+        '4' => '\u{2074}',
+        '5' => '\u{2075}',
+        '6' => '\u{2076}',
+        '7' => '\u{2077}',
+        '8' => '\u{2078}',
+        '9' => '\u{2079}',
+        _ => {
+            panic!("non-digit '{}'", regular_digit);
+        }
+    }
+}
+
+fn octal_superscript_u8(n: u8) -> String {
+    format!("{:o}", n).chars().map(superscript_digit).collect()
+}
+
+#[derive(Debug, Clone, Copy)]
+struct NoSubscriptKnown(char);
+
+impl Display for NoSubscriptKnown {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+	write!(f, "bug: no subscript mapping is yet implemented for '{}'", self.0)
+    }
+}
+
+impl Error for NoSubscriptKnown {}
+
+fn subscript_char(ch: char) -> Result<char, NoSubscriptKnown> {
+    match ch {
+        '0' => Ok('\u{2080}'),	// ₀
+        '1' => Ok('\u{2081}'),	// ₁
+        '2' => Ok('\u{2082}'),	// ₂
+        '3' => Ok('\u{2083}'),	// ₃
+        '4' => Ok('\u{2084}'),	// ₄
+        '5' => Ok('\u{2085}'),	// ₅
+        '6' => Ok('\u{2086}'),	// ₆
+        '7' => Ok('\u{2087}'),	// ₇
+        '8' => Ok('\u{2088}'),	// ₈
+        '9' => Ok('\u{2089}'),	// ₉
+	'-' => Ok('\u{208B}'),	// ₋
+	'.' => Ok('.'),		// there appears to be no subscript version
+        _ =>  Err(NoSubscriptKnown(ch)),
+    }
+}
+
+fn subscript(s: &str) -> Result<String, NoSubscriptKnown> {
+    s.chars().map(subscript_char).collect()
+}
+
+
+fn octal_subscript_number(n: u8) -> String {
+    subscript(&format!("{:o}", n)).unwrap()
+}
+
+fn write_opcode(op: Opcode, cfg: Unsigned5Bit, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+    // Where there is a supernumerary mnemonic, prefer it.
+    // This list is taken from table 7-3 in the Users
+    // Handbook.
+    let cfg = u8::from(cfg);
+    match op {
+	Opcode::Jmp => f.write_str(match cfg {
+	    0o00 => "JMP",
+	    0o01 => "BRC",
+	    0o02 => "JPS",
+	    0o03 => "BRS",
+	    0o14 => "JPQ",
+	    0o15 => "BPQ",
+	    0o16 => "JES",
+	    0o20 => "JPD",
+	    0o21 => "JMP",
+	    0o22 => "JDS",
+	    0o23 => "BDS",
+	    _ => "JMP",
+	}),
+	Opcode::Skx => f.write_str(match cfg {
+	    0o00 => "REX",
+	    0o02 => "INX",
+	    0o03 => "DEX",
+	    0o04 => "SXD",
+	    0o06 => "SXL",
+	    0o07 => "SXG",
+	    0o10 => "RXF",
+	    0o20 => "RXD",
+	    0o30 => "RFD",
+	    _ => "SKX",
+	}),
+	Opcode::Skm => f.write_str(match cfg {
+	    0o00 => "SKM",
+	    0o01 => "MKC",
+	    0o02 => "MKZ",
+	    0o03 => "MKN",
+	    0o10 => "SKU",
+	    0o11 => "SUC",
+	    0o12 => "SUZ",
+	    0o13 => "SUN",
+	    0o20 => "SKZ",
+	    0o21 => "SZC",
+	    0o22 => "SZZ",
+	    0o23 => "SZN",
+	    0o30 => "SKN",
+	    0o31 => "SNC",
+	    0o32 => "SNZ",
+	    0o33 => "SNN",
+	    0o04 => "CYR",
+	    0o05 => "MCR",
+	    0o06 => "MZR",
+	    0o07 => "MNR",
+	    0o34 => "SNR",
+	    0o24 => "SZR",
+	    0o14 => "SUR",
+	    _ => "SKM",
+	}),
+	_ => write!(f, "{}", op)
+    }
+}
+
+impl Display for SymbolicInstruction {
+    /// Convert a `SymbolicInstruction` to text (Unicode) form.
+    ///
+    /// We use supernumerary opcode mnemonics where one is suitable
+    /// (though we keep the original configuration value).
+    /// Configuration values are rendered as superscripts.  Index
+    /// addresses are rendered as subscripts and operand addresses as
+    /// normal digits.  These match the conventions used in the TX-2
+    /// User Handbook.
+    ///
+    /// The User Handbook indicates that the hold bit should be
+    /// represented as _h_ (lower-case "H") when 1 and as _h_ with
+    /// overbar when 0.  We diverge from this usage for consistency
+    /// with the M4 listing of the Sketchpad code, which uses a
+    /// leading colon to indicate _hold_.  However, since I wasn't
+    /// able to find a negative override (setting _hold_ to zero) in
+    /// the Sketchpad code, we use &#x0127; (a Unicode lower-case h
+    /// with stroke) to signal that.  When the defer bit takes the
+    /// value which is the default for the current instruction,
+    /// nothing (neither "h" nor "&#x0127;") is printed.
+    ///
+    /// The representation of instructions may change over time as we
+    /// discover archival material containing program listings.  The
+    /// idea is to generally be consistent with the materials we have
+    /// available.
+    ///
+    /// Instructions such as SKM should show the index address as a
+    /// bit selector, but this may not yet happen in all the cases we
+    /// would want it.  This will change over time as we implement
+    /// more of the instruction opcodes in the emulator.
+    ///
+    /// Some addresses (arithmetic unit registers for example) are
+    /// "well-known" but we do not currently display these in symbolic
+    /// form.
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+	// This implementation of Display is incomplete because, for
+	// example there are some instructions for which the index
+	// value is rendered as X.Y (I believe these are the
+	// bit-manipulation instructions).  The I/O instructions also
+	// have special cases.
+	//
+	// We also don't render "special" addresses, such as the
+	// addresses of actual registers, in symbolic form.
+        match (self.opcode().hold_is_implicit(), self.is_held()) {
+            (true, false) => {
+                // I didn't find any examples of this (a programmer
+                // override to make a normally-held opcode actually
+                // not held) in the documentation so far.
+                //
+                // We will use the notation given in section 6-2.1
+                // ("Instruction Words") of the User Handbook.
+                f.write_str("\u{0127} ")?; // lower-case h with stroke
+            }
+            (false, true) => {
+                f.write_str(": ")?;
+            }
+            _ => {
+                // This is the default, so it needs no annotation.
+            }
+        }
+        if !self.configuration().is_zero() {
+            let cf: u8 = self.configuration().into();
+            f.write_str(&octal_superscript_u8(cf))?;
+        }
+	write_opcode(self.opcode(), self.configuration(), f)?;
+	let j = self.index_address();
+	match self.opcode() {
+	    Opcode::Skm => {
+		// The index address field in SKM instructions
+		// identify a bit in the operand to operate on, and
+		// are shown in the form "q.b".  The "q" identifies
+		// the quarter and the "b" the bit.
+		let selector: BitSelector = index_address_to_bit_selection(j);
+		let rendering: String = subscript(&selector.to_string()).unwrap();
+		f.write_str(&rendering)?;
+	    }
+	    _ => {
+		if j != 0 {
+		    f.write_str(&octal_subscript_number(u8::from(j)))?;
+		}
+	    }
+	}
+        write!(f, " {:>08o}", self.operand_address()) // includes [] if needed.
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config_value(n: u8) -> Unsigned5Bit {
+        Unsigned5Bit::try_from(n).expect("valid test data")
+    }
+
+    fn addr(a: u32) -> Address {
+        Address::from(Unsigned18Bit::try_from(a).expect("valid test data"))
+    }
+
+    #[test]
+    fn test_octal_superscript_u8() {
+        assert_eq!(&octal_superscript_u8(0), "\u{2070}", "0 decimal is 0 octal");
+        assert_eq!(&octal_superscript_u8(1), "\u{00B9}", "1 decimal is 1 octal");
+        assert_eq!(
+            &octal_superscript_u8(4),
+            "\u{02074}",
+            "4 decimal is 4 octal"
+        );
+        assert_eq!(
+            &octal_superscript_u8(11),
+            "\u{00B9}\u{00B3}",
+            "11 decimal is 13 octal"
+        );
+        assert_eq!(
+            &octal_superscript_u8(255),
+            "\u{00B3}\u{2077}\u{2077}",
+            "255 decimal is 377 octal"
+        );
+    }
+
+    #[test]
+    fn test_display_jmp() {
+        let sinst = SymbolicInstruction {
+            operand_address: OperandAddress::Direct(Address::from(
+                Unsigned18Bit::try_from(0o0377750).expect("valid test data"),
+            )),
+            index: Unsigned6Bit::ZERO,
+            opcode: Opcode::Jmp,
+            configuration: Unsigned5Bit::ZERO,
+            held: false,
+        };
+        assert_eq!(&sinst.to_string(), "JMP 377750");
+    }
+
+    #[test]
+    fn test_display_jpx_sutherland() {
+        // Example from the plotter service routine from Ivan Sutherland's
+        // SKETCHPAD, as held by the Computer History museum, PDF file
+        // 102726903-05-02-acc.pdf page 124 (hand-written page number
+        // 274).
+        //
+        // -1 JPX $ UNITS OFF1        76 06 34 200 156
+        //
+        // The $ there is a placeholder (just in this comment) for a blob
+        // on the scanned page that I simply can't read.  The assembled
+        // word on the right-hand side is easier to read, but the value
+        // there (34 octal) doesn't seem to correspond very well with what
+        // looks like a single digit index value.
+        //
+        // Hold is used in conjunction with the JPX opcode in order to
+        // prevent DISMISS (see page 3-26 of the User Guide which
+        // describes JPX).  Hence the -1 seems reasonable, though in
+        // any case M4 automatically puts a hold on JPX (as described
+        // on page 3-27 of the user guide).
+        //
+        // The TSX-2 has a front-panel button "Hold on LSPB" which
+        // makes the system behave as if the hold bit were set on all
+        // instructions; see User Guide, page 5-17.
+        let sinst = SymbolicInstruction {
+            operand_address: OperandAddress::Direct(addr(0o0200156_u32)),
+            index: Unsigned6Bit::try_from(0o34_u8).unwrap(),
+            opcode: Opcode::Jpx,
+            configuration: config_value(0o36), // 036 octal = 30 decimal = 0b11110
+            held: true,
+        };
+        assert_eq!(&sinst.to_string(), "³⁶JPX₃₄ 200156");
+    }
+
+    #[test]
+    fn test_display_jpx_progex() {
+        // These cases are taken from the programming examples
+        // document (memo 6M-5780, July 23, 1958).
+
+        // Example from Program I, address 377 765, instruction word 36 06 01 377 751.
+        let sinst1 = SymbolicInstruction {
+            operand_address: OperandAddress::Direct(addr(0o0377751)),
+            index: Unsigned6Bit::ONE,
+            opcode: Opcode::Jpx,
+            // 036 = 30 decimal = 0b11110, which is one's complement -1.
+            configuration: config_value(0o36),
+
+            // In the example program, we see the octal equivalent of
+            // the instruction, and the top bit is clearly not set, so
+            // instruction is not held.
+            held: false,
+        };
+        // In the Program I listing, there is no annotation indicating
+        // that the instruction is not held.  This memo is from 1958.
+        // Perhaps the conventions changed between then and the date
+        // of the User Handbook (1963).
+        //
+        // The actual example gives a configuration value of -1, but
+        // we have to choose a single way to render config values
+        // (i.e. choose one of -1 or 36 for bit pattern 0b11110).
+        // Compare for example test_display_rsx(), which points to an
+        // example where the configuration value is formatted the
+        // other way.
+        assert_eq!(&sinst1.to_string(), "ħ ³⁶JPX₁ 377751");
+
+        // Example from Program II ("Inchworm"), address 15, instruction word not stated,
+        let sinst2 = SymbolicInstruction {
+            operand_address: OperandAddress::Direct(addr(0o0377752)),
+            index: Unsigned6Bit::try_from(3_u8).unwrap(),
+            opcode: Opcode::Jpx,
+            // In the Program II example, the configuration value is
+            // given as -7.  We're using octal 30 and believe that is
+            // equivalent.
+            configuration: Unsigned5Bit::try_from(0o30_u8).expect("valid test data"),
+            held: false,
+        };
+        // ħ here for the same reason as sinst1 disassembled above.
+        assert_eq!(&sinst2.to_string(), "ħ ³⁰JPX₃ 377752");
+    }
+
+    #[test]
+    fn test_display_rsx() {
+        // Example from Program II ("Inchworm"), address 377 755,
+        // instruction word 74 11 71 377 763.  Note the leading colon,
+        // indicating the hold bit.
+        let sinst = SymbolicInstruction {
+            operand_address: OperandAddress::Direct(addr(0o377762)),
+            index: Unsigned6Bit::try_from(0o71_u8).unwrap(),
+            opcode: Opcode::Rsx,
+            configuration: config_value(0o34),
+            held: true, // this is signaled by the colon.
+        };
+        assert_eq!(&sinst.to_string(), ": ³⁴RSX₇₁ 377762"); // the ':' indicates `held`
+    }
+}

--- a/base/src/instruction/mod.rs
+++ b/base/src/instruction/mod.rs
@@ -1,0 +1,612 @@
+//! Binary and symbolic representations of TX-2 instructions.
+//!
+//! A TX-2 instruction occupies 36 bits.  The 36 bits look like this
+//! (least significant bit on the right, bits numbered 0 to 35 in
+//! decimal):
+//!
+//! |Hold |Configuration| Opcode|Index  |Defer|Operand Memory Address|
+//! |-----|-------------|-------|-------|-----|----------------------|
+//! |1 bit|  5 bits     |6 bits |6 bits |1 bit|      17 bits         |
+//! |(35) | (30-34)     |(24-29)|(18-23)|     |       (0-16)         |
+//!
+//! This diagram is taken from section 6-2.1 "INSTRUCTION WORDS" of the
+//! TX-2 Users Handbook (page 6-4, being the 157th page of my PDF file).
+//!
+//! There is a similar diagram in Fig. 5 (p. 11) of "A Functional
+//! Description of the Lincoln TX-2 Computer" by John M. Frankovitch
+//! and H. Philip Peterson, but that is older and, I believe,
+//! inaccurate in the width of the configuration field for example.
+//! Section 6-2.1 of the User Handbook confirms that the configuration
+//! "syllable" is 5 bits.
+//!
+//! Table 7-2 in the user guide defines values of `cf` for the range 0
+//! to 037 inclusive in terms of the standard contents that they fetch
+//! from the F-memory.
+//!
+//! In the programming examples (6M-5780, page 6) we have
+//!
+//! `34 21 00 377,751     34SPF 377751`
+//!
+//! Here, the operand memory address is 0377751.  The index is 00.
+//! The opcode is `SPF`, octal 21.  The top 6 bits are 034, or 11100
+//! binary.  The user guide states that `SPF` is not configurable, so
+//! presumably the configuration field simply specifies the address in
+//! F-memory that we will write to.
+//!
+//! Later in the same page we have
+//!
+//! `74 11 71 377,762    34RSX71  377,762`
+//!
+//! RSX is opcode 11.  Hence the top 6 bits are 074 = 111100 binary,
+//! Of those only 034=11100 binary seem to be configuration code.  But
+//! the hold bit seems to be set without this being indicated in the
+//! symbolic form of the instruction.
+
+use std::fmt::{self, Debug, Formatter};
+
+use crate::prelude::*;
+use crate::subword;
+
+mod format;
+
+
+/// `Quarter` describes which quarter of a word an SKM instruction
+/// will operate on.  See the [`index_address_to_bit_selection`]
+/// function.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Quarter {
+    Q1 = 0,
+    Q2 = 1,
+    Q3 = 2,
+    Q4 = 3,
+}
+
+/// Convert the `Quarter` enumeration value into the position of that
+/// quarter (counting from the least-significant end of the 36-bit
+/// word).
+impl From<Quarter> for u8 {
+    fn from(q: Quarter) -> u8 {
+	match q {
+	    Quarter::Q1 => 0,
+	    Quarter::Q2 => 1,
+	    Quarter::Q3 => 2,
+	    Quarter::Q4 => 3,
+	}
+    }
+}
+
+/// `BitSelector` is primarily for use with the SKM instruction which
+/// can access bits 1-9 of quarters, plus the meta and parity bits (of
+/// the full word).  Hence the wider range.  See the
+/// [`index_address_to_bit_selection`] function.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct BitSelector {
+    pub quarter: Quarter,
+    /// `bitpos` values 1 to 9 inclusive are normal bit positions in a
+    /// quarter.  0 is a valid value but not a valid bit (so a default
+    /// will be used when SKM tests bit 0).  10 is the meta bit.  11
+    /// is the parity bit stored in memory.  12 is the parity value
+    /// computed from the bits stored in memory.
+    pub bitpos: u8,	// takes values 0..=12.
+}
+
+/// Convert the index address field of an SKM instruction into a
+/// `BitSelector` struct describing which bit we will operate on.
+pub fn index_address_to_bit_selection(index_address: Unsigned6Bit) -> BitSelector {
+    let j: u8 = u8::from(index_address);
+    BitSelector {
+	quarter: match (j >> 4) & 0b11 {
+	    0 => Quarter::Q4,
+	    1 => Quarter::Q1,
+	    2 => Quarter::Q2,
+	    3 => Quarter::Q3,
+	    _ => unreachable!(),
+	},
+	bitpos: j & 0b1111_u8,
+    }
+}
+
+/// A TX-2 Instruction.
+#[derive(Clone, Copy)]
+pub struct Instruction(Unsigned36Bit);
+
+impl Instruction {
+    /// Returns an unspecified invalid instruction.
+    pub fn invalid() -> Instruction {
+        Instruction(Unsigned36Bit::ZERO)
+    }
+}
+
+impl From<Unsigned36Bit> for Instruction {
+    fn from(w: Unsigned36Bit) -> Instruction {
+        Instruction(w)
+    }
+}
+
+impl From<Instruction> for Unsigned36Bit {
+    fn from(inst: Instruction) -> Unsigned36Bit {
+	inst.0
+    }
+}
+
+impl Debug for Instruction {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+        let lhs = match SymbolicInstruction::try_from(self) {
+            Ok(sym) => format!("{}", sym),
+            Err(e) => format!("(invalid instruction: {})", e),
+        };
+        write!(f, "{:<40} {}", lhs, self.0)
+    }
+}
+
+/// The `Inst` trait provides a way to extract the various fields
+/// within an instruction.
+pub trait Inst {
+    /// Obtain the value of the "hold" bit.
+    fn is_held(&self) -> bool;
+
+    /// Fetch the configuration field of the instruction.  This is
+    /// used as an index to fetch a system configuration from the
+    /// F-memory.  Table 7-2 in the TX-2 User Handbook explains what
+    /// data exists in the F-memory in the standard configuration.
+    ///
+    /// The meaning of the values fetched from the F-memory (and thus,
+    /// the significance of the configuration values of an
+    /// instruction) is explained in Volume 2 (pages 12-19) of the
+    /// Technical manual.  Some instructions (JMP, for example) use
+    /// this field differently.
+    fn configuration(&self) -> Unsigned5Bit;
+
+    /// indexation is actually a signed operation (see the [`IndexBy`]
+    /// trait) but index addresses are shown as positive numbers
+    /// (e.g. 77) in assembler source code.
+    fn index_address(&self) -> Unsigned6Bit;
+
+    /// The opcode of the instruction.
+    fn opcode_number(&self) -> u8;
+
+    /// The value of the defer bit from the operand address field.
+    fn is_deferred_addressing(&self) -> bool;
+
+    /// The operand address field (including the defer bit)
+    fn operand_address(&self) -> OperandAddress;
+
+    /// Fetches the operand address with the defer bit (if set) in bit
+    /// position 17.
+    fn operand_address_and_defer_bit(&self) -> Unsigned18Bit;
+}
+
+impl Inst for Instruction {
+    fn is_held(&self) -> bool {
+        const HOLD_BIT: u64 = 1_u64 << 35;
+        !(self.0 & HOLD_BIT).is_zero()
+    }
+
+    fn configuration(&self) -> Unsigned5Bit {
+        let val: u8 = u8::try_from((self.0 >> 30) & 31_u64).unwrap();
+        Unsigned5Bit::try_from(val).unwrap()
+    }
+
+    fn opcode_number(&self) -> u8 {
+        u8::try_from((self.0 >> 24) & 63_u64).unwrap()
+    }
+
+    fn index_address(&self) -> Unsigned6Bit {
+        Unsigned6Bit::try_from((self.0 >> 18) & 63_u64).unwrap()
+    }
+
+    fn is_deferred_addressing(&self) -> bool {
+        self.0 & 0o400_000_u64 != 0
+    }
+
+    fn operand_address(&self) -> OperandAddress {
+        const PHYSICAL_ADDRESS_BITS: u32 = 0o377_777;
+        let physical_address = Address::from(subword::right_half(self.0) & PHYSICAL_ADDRESS_BITS);
+        if self.0 & 0o400_000 != 0 {
+            OperandAddress::Deferred(physical_address)
+        } else {
+            OperandAddress::Direct(physical_address)
+        }
+    }
+
+    fn operand_address_and_defer_bit(&self) -> Unsigned18Bit {
+        let bits: u32 = u32::try_from(self.0 & 0o777_777).unwrap();
+        Unsigned18Bit::try_from(bits).unwrap() // range already checked above.
+    }
+}
+
+/// `Opcode` enumerates all the valid TX-2 opcodes.  These values are
+/// taken from the User Handbook.  Volume 3 of the Technical Manual
+/// (page 1-5-3) describes opcodes 00, 01, 02, 03, 04 (mentioning bit
+/// 2.8 of N being in state 1), 13, 23, 33, 45, 50, 51, 52, 53, 63, 73
+/// as being undefined.
+///
+/// Different copies of the User Handbook differ in the description of
+/// opcodes 0o44 and 0o45.
+#[repr(u8)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum Opcode {
+    // opcode 1 is unused
+    // opcode 2 may be XEQ, but no documentation on this.
+    // opcode 3 is unused
+    Ios = 0o4, // see also Vol 3 page 16-05-07
+    Jmp = 0o5,
+    Jpx = 0o6,
+    Jnx = 0o7,
+    Aux = 0o10,
+    Rsx = 0o11,
+    Skx = 0o12,
+    // opcode 0o13 = 11 is undefined (unused).
+    Exx = 0o14,
+    Adx = 0o15,
+    Dpx = 0o16,
+    Skm = 0o17,
+    Lde = 0o20,
+    Spf = 0o21,
+    Spg = 0o22,
+    // opcode 0o23 = 19 is undefined (unused).
+    Lda = 0o24,
+    Ldb = 0o25,
+    Ldc = 0o26,
+    Ldd = 0o27,
+    Ste = 0o30,
+    Flf = 0o31,
+    Flg = 0o32,
+    // opcode 033 = 27 is unused.
+    Sta = 0o34,
+    Stb = 0o35,
+    Stc = 0o36,
+    Std = 0o37,
+    Ite = 0o40,
+    Ita = 0o41,
+    Una = 0o42,
+    Sed = 0o43,
+
+    /// I have two copies of the User Handbook and they differ in
+    /// their description of opcodes 0o44, 0o45.
+    ///
+    /// In the August 1963 copy, 0o44 is missing and 0045 is JOV.
+    ///
+    /// In the index of the October 1961 copy, 0o44 is JOV and 0o45 is
+    /// JZA (handwritten).  However, in this copy, page 3-32 (which
+    /// describes JPA, JNA, JOV) gives JOV as 0o45.  So I assume this
+    /// is just an error in the index.  This copy does not otherwise
+    /// describe a JZA opcode.
+    Jov = 0o45,
+
+    Jpa = 0o46,
+    Jna = 0o47,
+    // opcode 0o50 = 40 is undefined (unused).
+    // opcode 0o51 = 41 is undefined (unused).
+    // opcode 0o52 = 42 is undefined (unused).
+    // opcode 0o53 = 43 is undefined (unused).
+    Exa = 0o54,
+    Ins = 0o55,
+    Com = 0o56,
+    Tsd = 0o57,
+    Cya = 0o60,
+    Cyb = 0o61,
+    Cab = 0o62,
+    // opcode 0o63 = 51 is unused.
+    Noa = 0o64,
+    Dsa = 0o65,
+    Nab = 0o66,
+    Add = 0o67,
+    Sca = 0o70,
+    Scb = 0o71,
+    Sab = 0o72,
+    // opcode 0o71 = 59 is unused.
+    Tly = 0o74,
+    Div = 0o75,
+    Mul = 0o76,
+    Sub = 0o77,
+}
+
+impl Opcode {
+    pub fn number(&self) -> u8 {
+        *self as u8
+    }
+
+    pub fn hold_is_implicit(&self) -> bool {
+	matches!(self, Opcode::Lde | Opcode::Ite | Opcode::Jpx | Opcode::Jnx)
+    }
+}
+
+impl TryFrom<u8> for Opcode {
+    type Error = DisassemblyFailure;
+    fn try_from(opcode: u8) -> Result<Opcode, DisassemblyFailure> {
+        use Opcode::*;
+        match opcode {
+            // TODO: change these opcode values to octal.
+            0 | 1 => Err(DisassemblyFailure::InvalidOpcode(opcode)),
+            2 => {
+                // Maybe XEQ?
+                Err(DisassemblyFailure::UnimplementedOpcode(opcode))
+            }
+            3 => Err(DisassemblyFailure::InvalidOpcode(opcode)),
+            0o4 => Ok(Ios),
+            0o5 => Ok(Jmp),
+            0o6 => Ok(Jpx),
+            0o7 => Ok(Jnx),
+            0o10 => Ok(Aux),
+            0o11 => Ok(Rsx),
+            0o12 => Ok(Skx),
+            11 => Err(DisassemblyFailure::InvalidOpcode(opcode)),
+            12 => Ok(Exx),
+            13 => Ok(Adx),
+            14 => Ok(Dpx),
+            15 => Ok(Skm),
+            16 => Ok(Lde),
+            17 => Ok(Spf),
+            18 => Ok(Spg),
+            19 => Err(DisassemblyFailure::InvalidOpcode(opcode)),
+            20 => Ok(Lda),
+            21 => Ok(Ldb),
+            22 => Ok(Ldc),
+            23 => Ok(Ldd),
+            24 => Ok(Ste),
+            25 => Ok(Flf),
+            26 => Ok(Flg),
+            27 => Err(DisassemblyFailure::InvalidOpcode(opcode)),
+            28 => Ok(Sta),
+            29 => Ok(Stb),
+            30 => Ok(Stc),
+            31 => Ok(Std),
+            32 => Ok(Ite),
+            33 => Ok(Ita),
+            34 => Ok(Una),
+            35 => Ok(Sed),
+            // 36 is unused
+            36 => Err(DisassemblyFailure::InvalidOpcode(opcode)),
+            37 => Ok(Jov),
+            38 => Ok(Jpa),
+            39 => Ok(Jna),
+            40..=43 => Err(DisassemblyFailure::InvalidOpcode(opcode)),
+            44 => Ok(Exa),
+            45 => Ok(Ins),
+            46 => Ok(Com),
+            47 => Ok(Tsd),
+            48 => Ok(Cya),
+            49 => Ok(Cyb),
+            50 => Ok(Cab),
+            51 => Err(DisassemblyFailure::InvalidOpcode(opcode)),
+            52 => Ok(Noa),
+            53 => Ok(Dsa),
+            54 => Ok(Nab),
+            55 => Ok(Add),
+            56 => Ok(Sca),
+            57 => Ok(Scb),
+            58 => Ok(Sab),
+            59 => Err(DisassemblyFailure::InvalidOpcode(opcode)),
+            60 => Ok(Tly),
+            61 => Ok(Div),
+            62 => Ok(Mul),
+            63 => Ok(Sub),
+            _ => Err(DisassemblyFailure::InvalidOpcode(opcode)),
+        }
+    }
+}
+
+/// OperandAddress represents the least-significant 18 bits of an
+/// instruction word.  By using an enumeration for this we make it
+/// harder to accidentally mix up operand addresses (which might have
+/// a defer bit) and physical addresses (which only have 17 useful
+/// bits, since the highest physical memory address is 377 777).
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum OperandAddress {
+    Direct(Address),
+    Deferred(Address),
+}
+
+/// A TX-2 instruction broken down into its component fields.
+#[derive(Debug, PartialEq, Eq)]
+pub struct SymbolicInstruction {
+    operand_address: OperandAddress,
+    index: Unsigned6Bit,
+    opcode: Opcode,
+    configuration: Unsigned5Bit,
+    held: bool,
+}
+
+impl SymbolicInstruction {
+    pub fn opcode(&self) -> Opcode {
+        self.opcode
+    }
+}
+
+impl Inst for SymbolicInstruction {
+    fn is_held(&self) -> bool {
+        self.held
+    }
+
+    fn configuration(&self) -> Unsigned5Bit {
+        self.configuration
+    }
+
+    fn index_address(&self) -> Unsigned6Bit {
+        self.index
+    }
+
+    fn opcode_number(&self) -> u8 {
+        self.opcode.number()
+    }
+
+    fn is_deferred_addressing(&self) -> bool {
+        matches!(self.operand_address, OperandAddress::Deferred(_))
+    }
+
+    fn operand_address(&self) -> OperandAddress {
+        self.operand_address
+    }
+
+    fn operand_address_and_defer_bit(&self) -> Unsigned18Bit {
+	const ADDRESS_DEFER_BIT: u32 = 0o400_000;
+        match self.operand_address {
+            OperandAddress::Deferred(addr) => {
+                let defer_bit = Unsigned18Bit::try_from(ADDRESS_DEFER_BIT).unwrap();
+                Unsigned18Bit::from(addr) | defer_bit
+            }
+            OperandAddress::Direct(addr) => Unsigned18Bit::from(addr),
+        }
+    }
+}
+
+impl From<&SymbolicInstruction> for Instruction {
+    fn from(s: &SymbolicInstruction) -> Instruction {
+        let hold_bit: u64 = if s.is_held() { 1 << 35 } else { 0 };
+        let cf_bits: u64 = (u64::from(s.configuration()) & 31_u64) << 30;
+        let op_bits: u64 = (u64::from(s.opcode_number()) & 63) << 24;
+        let address_and_defer_bits: u64 = s.operand_address_and_defer_bit().into();
+        let val: u64 = hold_bit | cf_bits | op_bits | address_and_defer_bits;
+        Instruction(Unsigned36Bit::try_from(val).unwrap())
+    }
+}
+
+/// Signals that an [`Instruction`] could not be converted to a
+/// [`SymbolicInstruction`].
+#[derive(PartialEq, Eq)]
+pub enum DisassemblyFailure {
+    /// The opcode field of the instruction word does not correspond
+    /// to a known opcode.
+    InvalidOpcode(u8),
+
+    /// The opcode field of the instruction word corresponds to an
+    /// operation we know nothing about.  This enumerator shouldn't be
+    /// considered stable; we might remove it entirely.  Currently only
+    /// opcode 2 yields this result (corresponding to "XEQ?"
+    /// hand-written on a copy of the User Handbook).
+    UnimplementedOpcode(u8),
+}
+
+impl Debug for DisassemblyFailure {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+        let opcode = match self {
+            DisassemblyFailure::InvalidOpcode(n) => {
+                f.write_str("InvalidOpcode")?;
+                n
+            }
+            DisassemblyFailure::UnimplementedOpcode(n) => {
+                f.write_str("UnimplementedOpcode")?;
+                n
+            }
+        };
+        write!(f, "(0{:o})", opcode)
+    }
+}
+
+impl TryFrom<&Instruction> for SymbolicInstruction {
+    type Error = DisassemblyFailure;
+    fn try_from(inst: &Instruction) -> Result<SymbolicInstruction, DisassemblyFailure> {
+        Ok(SymbolicInstruction {
+            operand_address: inst.operand_address(),
+            index: inst.index_address(),
+            opcode: Opcode::try_from(inst.opcode_number())?,
+            configuration: inst.configuration(),
+            held: inst.is_held(),
+        })
+    }
+}
+
+// disassemble_word is intended to be used in the emulator's UI to
+// show what the program counter is pointing at, and to show the next
+// instruction to be emulated etc.  Since this is not yet implemented,
+// right now the only callers are unit tests.
+#[cfg(test)]
+pub fn disassemble_word(w: Unsigned36Bit) -> Result<SymbolicInstruction, DisassemblyFailure> {
+    let inst: Instruction = Instruction(w);
+    dbg!(inst.operand_address());
+    SymbolicInstruction::try_from(&inst)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config_value(n: u8) -> Unsigned5Bit {
+        Unsigned5Bit::try_from(n).expect("valid test data")
+    }
+
+    fn addr(a: u32) -> Address {
+        Address::from(Unsigned18Bit::try_from(a).expect("valid test data"))
+    }
+
+    #[test]
+    fn test_instruction_jmp() {
+        let inst = Instruction(Unsigned36Bit::from(0o0500377750_u32));
+        assert_eq!(
+            inst.operand_address(),
+            OperandAddress::Direct(addr(0o0377750_u32)),
+            "wrong address"
+        );
+        assert_eq!(inst.is_deferred_addressing(), false, "wrong dismis");
+        assert_eq!(inst.index_address(), 0, "wrong index");
+        assert_eq!(inst.opcode_number(), 5, "wrong opcode");
+        assert!(inst.configuration().is_zero(), "wrong cf");
+        assert_eq!(inst.is_held(), false, "wrong held");
+    }
+
+    #[test]
+    fn test_instruction_held() {
+        assert!(!Instruction(Unsigned36Bit::ZERO).is_held());
+        assert!(Instruction(
+            Unsigned36Bit::try_from(1_u64 << 35).expect("test data should be in-range")
+        )
+        .is_held());
+    }
+
+    #[test]
+    fn test_opcode_value_round_trip() {
+        for opcode_number in 0..u8::MAX {
+            if let Ok(opcode) = Opcode::try_from(opcode_number) {
+                assert_eq!(opcode_number, opcode.number());
+            }
+        }
+    }
+
+    #[test]
+    fn test_disassemble_jmp() {
+        assert_eq!(
+            disassemble_word(
+                Unsigned36Bit::try_from(0o000_500_377_750).expect("test data should be in range")
+            ),
+            Ok(SymbolicInstruction {
+                operand_address: OperandAddress::Direct(addr(0o0377750)),
+                index: Unsigned6Bit::ZERO,
+                opcode: Opcode::Jmp,
+                configuration: config_value(0),
+                held: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_disassemble_jpx() {
+        assert_eq!(
+            disassemble_word(
+                Unsigned36Bit::try_from(0o700_603_377_752_u64)
+                    .expect("test data should be in range")
+            ),
+            Ok(SymbolicInstruction {
+                operand_address: OperandAddress::Direct(addr(0o0377752)),
+                index: Unsigned6Bit::try_from(3_u8).unwrap(),
+                opcode: Opcode::Jpx,
+                configuration: config_value(24), // -7
+                held: true,
+            })
+        );
+
+        assert_eq!(
+            disassemble_word(
+                Unsigned36Bit::try_from(0o360_601_377_751_u64)
+                    .expect("test data should be in range")
+            ),
+            Ok(SymbolicInstruction {
+                operand_address: OperandAddress::Direct(addr(0o0377751)),
+                index: Unsigned6Bit::ONE,
+                opcode: Opcode::Jpx,
+                configuration: config_value(30),
+                held: false,
+            })
+        );
+    }
+}

--- a/base/src/lib.rs
+++ b/base/src/lib.rs
@@ -1,0 +1,12 @@
+//! The `base` crate defines the TX2-related things which are useful
+//! in both a simulator and other associated tools.  The idea is that
+//! if you want to write an assembler, it would depend on the base
+//! crate but would not need to depend on the simulator library
+//! itself.
+
+mod onescomplement;
+mod types;
+
+pub mod instruction;
+pub mod prelude;
+pub mod subword;

--- a/base/src/onescomplement/error.rs
+++ b/base/src/onescomplement/error.rs
@@ -1,0 +1,23 @@
+//! Basic error reporting.
+
+use std::error::Error;
+use std::fmt::{self, Debug, Display, Formatter};
+
+/// Represents a failure to convert to or from one of the signed or
+/// unsigned types defined in the base crate.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ConversionFailed {
+    TooLarge,
+    TooSmall,
+}
+
+impl Error for ConversionFailed {}
+
+impl Display for ConversionFailed {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+        match self {
+            ConversionFailed::TooLarge => f.write_str("value is too large"),
+            ConversionFailed::TooSmall => f.write_str("value is too small"),
+        }
+    }
+}

--- a/base/src/onescomplement/mod.rs
+++ b/base/src/onescomplement/mod.rs
@@ -1,0 +1,23 @@
+//! This module implements one's complement fixed-width signed types
+//! for use in emulating the TX-2, plus related unsigned types of the
+//! same width.
+
+pub mod error;
+pub mod signed;
+pub mod unsigned;
+
+/// The sign of a number.  Although in a one's-complement system all
+/// values have a sign, we treat zero specially in order to simplify
+/// working with native types and one's-complement types together.
+pub enum Sign {
+    Negative = -1, // <= -1
+    Zero = 0,      // +0 or -0
+    Positive = 1,  // >= +1
+}
+
+/// Trait common to both signed one's-complement types (defined in the
+/// [`signed`] module) and unsigned types (defined in the [`unsigned`]
+/// module).
+pub trait WordCommon {
+    fn signum(&self) -> Sign;
+}

--- a/base/src/onescomplement/signed/mod.rs
+++ b/base/src/onescomplement/signed/mod.rs
@@ -1,0 +1,499 @@
+use std::cmp::Ordering;
+use std::fmt::{self, Debug, Formatter, Octal};
+use std::hash::{Hash, Hasher};
+
+use super::error::ConversionFailed;
+use super::{Sign, WordCommon};
+use super::unsigned::*;
+
+#[cfg(test)]
+mod tests18;
+#[cfg(test)]
+mod tests36;
+#[cfg(test)]
+mod tests5;
+#[cfg(test)]
+mod tests9;
+
+// This macro implements conversions from native types to Unsigned*Bit
+// which are always possible (e.g. From<i8> for Signed9Bit).
+macro_rules! from_native_type_to_self {
+    ($SelfT:ty, $InnerT:ty, $SignedInnerT:ty, $($from:ty)*) => {
+	$(
+	    impl From<$from> for $SelfT {
+		fn from(n: $from) -> Self {
+		    let v: $SignedInnerT = n.into();
+		    Self {
+			bits: <$SelfT>::convert_to_ones_complement(v),
+		    }
+		}
+	    }
+	)*
+    }
+}
+
+macro_rules! try_from_native_type_to_self {
+    ($SelfT:ty, $InnerT:ty, $SignedInnerT:ty, $($from:ty)*) => {
+	$(
+	    impl TryFrom<$from> for $SelfT {
+		type Error = ConversionFailed;
+		fn try_from(n: $from) -> Result<$SelfT, ConversionFailed> {
+		    match n.try_into() {
+			Err(_) if n > 0 => Err(ConversionFailed::TooLarge),
+			Err(_) => Err(ConversionFailed::TooSmall),
+			Ok(signed_value) => {
+			    if signed_value > (Self::VALUE_BITS as $SignedInnerT) {
+				Err(ConversionFailed::TooLarge)
+			    } else if signed_value < -(Self::VALUE_BITS as $SignedInnerT) {
+				Err(ConversionFailed::TooSmall)
+			    } else {
+				Ok(Self {
+				    bits: <$SelfT>::convert_to_ones_complement(signed_value)
+				})
+			    }
+			}
+		    }
+		}
+	    }
+	)*
+    }
+}
+
+// This macro implements conversions from Unsigned*Bit to native types
+// which are always possible (e.g. From<Signed9Bit> for i16).
+macro_rules! from_self_to_native_type {
+    ($SelfT:ty, $InnerT:ty, $SignedInnerT:ty, $($to:ty)*) => {
+	$(
+	    impl From<$SelfT> for $to {
+		fn from(n: $SelfT) -> $to {
+		    if n.is_zero() {
+			0 as Self
+		    } else if n.is_negative() {
+			let inverted_bits = (!n.bits) & <$SelfT>::VALUE_BITS;
+			let absolute_value = inverted_bits as $SignedInnerT;
+			(-absolute_value) as Self
+		    } else {
+			n.bits as Self
+		    }
+		}
+	    }
+	)*
+    }
+}
+
+// This macro implements conversions from Unsigned*Bit to native types
+// which may not always be possible (e.g. From<Signed18Bit> for u16).
+macro_rules! try_from_self_to_native_type {
+    ($SelfT:ty, $InnerT:ty, $SignedInnerT:ty, $($to:ty)*) => {
+	$(
+	    impl TryFrom<$SelfT> for $to {
+		type Error = ConversionFailed;
+		fn try_from(n: $SelfT) -> Result<$to, ConversionFailed> {
+		    if n.is_zero() {
+			return Ok(0);
+		    }
+		    #[allow(unused_comparisons)]
+		    if n.is_negative() {
+			let inverted_bits: $InnerT = (!n.bits) & <$SelfT>::VALUE_BITS;
+			let absolute_value: $SignedInnerT = inverted_bits as $SignedInnerT;
+			<$to>::try_from(-absolute_value)
+			    .map_err(|_| ConversionFailed::TooSmall)
+		    } else {
+			<$to>::try_from(n.bits)
+			    .map_err(|_| ConversionFailed::TooLarge)
+		    }
+		}
+	    }
+	)*
+    }
+}
+
+macro_rules! signed_ones_complement_impl {
+    ($SelfT:ty, $BITS:expr, $InnerT:ty, $SignedInnerT:ty, $UnsignedPeerT:ty) => {
+        impl $SelfT {
+            const SIGN_BIT: $InnerT = 1 << ($BITS - 1);
+            const VALUE_BITS: $InnerT = Self::SIGN_BIT - 1;
+            const ALL_BITS: $InnerT = Self::SIGN_BIT | Self::VALUE_BITS;
+
+            pub const MAX: Self = Self {
+                bits: Self::VALUE_BITS,
+            };
+
+            pub const MIN: Self = Self {
+                bits: Self::SIGN_BIT,
+            };
+
+            pub const ZERO: Self = Self { bits: 0 };
+            pub const ONE: Self = Self { bits: 1 };
+
+            pub const fn is_zero(&self) -> bool {
+                self.bits == 0 || self.bits == Self::ALL_BITS
+            }
+
+	    pub const fn reinterpret_as_unsigned(&self) -> $UnsignedPeerT {
+		type T = $UnsignedPeerT;
+		T { bits: self.bits }
+	    }
+
+            pub const fn is_negative(&self) -> bool {
+                self.bits & Self::SIGN_BIT != 0 && !self.is_zero()
+            }
+
+            pub const fn is_positive(&self) -> bool {
+                self.bits & Self::SIGN_BIT == 0 || self.is_zero()
+            }
+
+            pub const fn convert_to_ones_complement(signed: $SignedInnerT) -> $InnerT {
+                if signed < 0 {
+                    let absolute: $InnerT = (-signed) as $InnerT;
+                    let bits: $InnerT = (!absolute) & Self::ALL_BITS;
+                    bits
+                } else {
+                    signed as $InnerT
+                }
+            }
+
+            pub fn checked_add(self, rhs: $SelfT) -> Option<$SelfT> {
+                let left = <$SignedInnerT>::from(self);
+                let right = <$SignedInnerT>::from(rhs);
+                match left.checked_add(right) {
+                    Some(result) => Self::try_from(result).ok(),
+                    None => None,
+                }
+            }
+
+            pub fn checked_sub(self, rhs: $SelfT) -> Option<$SelfT> {
+                let left = <$SignedInnerT>::from(self);
+                let right = <$SignedInnerT>::from(rhs);
+                match left.checked_sub(right) {
+                    Some(result) => Self::try_from(result).ok(),
+                    None => None,
+                }
+            }
+
+	    pub fn wrapping_add(self, rhs: $SelfT) -> $SelfT {
+                let left = <$SignedInnerT>::from(self);
+                let right = <$SignedInnerT>::from(rhs);
+		let (result, overflow) = left.overflowing_add(right);
+		if overflow {
+		    panic!("bug: $SignedInnerT is not wide enough to perform no-overflow arithmetic");
+		}
+		const MODULUS: $SignedInnerT = 1 << ($BITS - 1);
+		Self {
+		    bits: Self::convert_to_ones_complement(result % MODULUS),
+		}
+	    }
+
+	    pub fn wrapping_sub(self, rhs: $SelfT) -> $SelfT {
+                let left = <$SignedInnerT>::from(self);
+                let right = <$SignedInnerT>::from(rhs);
+		let (result, overflow) = left.overflowing_sub(right);
+		if overflow {
+		    panic!("bug: $SignedInnerT is not wide enough to perform no-overflow arithmetic");
+		}
+		const MODULUS: $SignedInnerT = 1 << ($BITS - 1);
+		Self {
+		    bits: Self::convert_to_ones_complement(result % MODULUS),
+		}
+	    }
+
+            pub const fn abs(self) -> Self {
+                if self.is_zero() {
+                    Self::ZERO
+                } else if self.is_negative() {
+                    Self {
+                        bits: (!self.bits) & Self::VALUE_BITS,
+                    }
+                } else {
+                    self
+                }
+            }
+
+            pub const fn overflowing_abs(self) -> (Self, bool) {
+                (self.abs(), false)
+            }
+        }
+
+        impl Default for $SelfT {
+            fn default() -> Self {
+                Self { bits: 0 }
+            }
+        }
+
+        impl Octal for $SelfT {
+            fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+                Octal::fmt(&self.bits, f)
+            }
+        }
+
+        impl Debug for $SelfT {
+            fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+                write!(f, concat!(stringify!($SelfT), "{{bits: {:#o}}}"), self.bits)
+            }
+        }
+
+        impl Hash for $SelfT {
+            fn hash<H>(&self, state: &mut H)
+            where
+                H: Hasher,
+            {
+                if self.is_zero() {
+                    // -0 should hash to the same value as +0.
+                    let instead: $InnerT = 0;
+                    instead.hash(state)
+                } else {
+                    self.bits.hash(state)
+                }
+            }
+        }
+
+        impl PartialEq for $SelfT {
+            fn eq(&self, other: &$SelfT) -> bool {
+                match self.cmp(other) {
+                    Ordering::Equal => true,
+                    _ => false,
+                }
+            }
+        }
+
+        impl PartialEq<$SignedInnerT> for $SelfT {
+            fn eq(&self, other: &$SignedInnerT) -> bool {
+                match self.partial_cmp(other) {
+                    Some(Ordering::Equal) => true,
+                    _ => false,
+                }
+            }
+        }
+
+        impl Eq for $SelfT {}
+
+        impl PartialOrd for $SelfT {
+            fn partial_cmp(&self, other: &$SelfT) -> Option<Ordering> {
+                Some(self.cmp(other))
+            }
+        }
+
+        impl PartialOrd<$SignedInnerT> for $SelfT {
+            fn partial_cmp(&self, other: &$SignedInnerT) -> Option<Ordering> {
+                let lhs = <$SignedInnerT>::from(*self);
+                Some(lhs.cmp(other))
+            }
+        }
+
+        impl Ord for $SelfT {
+            fn cmp(&self, other: &$SelfT) -> Ordering {
+                // We perform conversion here so that -0 == +0.
+                let lhs = <$SignedInnerT>::from(*self);
+                let rhs = <$SignedInnerT>::from(*other);
+                lhs.cmp(&rhs)
+            }
+        }
+
+        impl WordCommon for $SelfT {
+            fn signum(&self) -> Sign {
+                if self.is_zero() {
+                    Sign::Zero
+                } else if self.is_negative() {
+                    Sign::Negative
+                } else {
+                    Sign::Positive
+                }
+            }
+        }
+    };
+}
+
+////////////////////////////////////////////////////////////////////////
+// Signed5Bit
+////////////////////////////////////////////////////////////////////////
+
+/// Signed5Bit is somewhat special-purpose for instructions such as
+/// JPX which use the instruction's configuration value as a 5-bit
+/// signed integer.
+#[derive(Clone, Copy)]
+pub struct Signed5Bit {
+    pub(crate) bits: u8,
+}
+
+signed_ones_complement_impl!(Signed5Bit, 5, u8, i8, Unsigned5Bit);
+
+// We only support a limited set of conversions.
+
+// i8 -> Signed5Bit
+// u8 -> Signed5Bit
+try_from_native_type_to_self!(Signed5Bit, u8, i8, i8 u8);
+
+// Signed5Bit -> i8
+from_self_to_native_type!(Signed5Bit, u8, i8, i8);
+try_from_self_to_native_type!(Signed5Bit, u8, i8, u8);
+
+////////////////////////////////////////////////////////////////////////
+// Signed6Bit
+////////////////////////////////////////////////////////////////////////
+
+/// Signed6Bit is somewhat special-purpose as the signed counterpart
+/// for Unsigned6Bit, which is for handlng index register numbers and
+/// sequence numbers.
+#[derive(Clone, Copy)]
+pub struct Signed6Bit {
+    pub(crate) bits: u8,
+}
+
+signed_ones_complement_impl!(Signed6Bit, 6, u8, i8, Unsigned6Bit);
+
+// We only support a limited set of conversions.
+
+// i8 -> Signed6Bit
+// u8 -> Signed6Bit
+try_from_native_type_to_self!(Signed6Bit, u8, i8, i8 u8);
+
+// Signed6Bit -> i8
+from_self_to_native_type!(Signed6Bit, u8, i8, i8);
+try_from_self_to_native_type!(Signed6Bit, u8, i8, u8);
+
+////////////////////////////////////////////////////////////////////////
+// Signed9Bit
+////////////////////////////////////////////////////////////////////////
+
+/// Signed counterpart of [`Unsigned9Bit`].
+#[derive(Clone, Copy)]
+pub struct Signed9Bit {
+    pub(crate) bits: u16,
+}
+
+signed_ones_complement_impl!(Signed9Bit, 9, u16, i16, Unsigned9Bit);
+
+// i8 -> Signed9Bit
+// u8 -> Signed9Bit
+from_native_type_to_self!(Signed9Bit, u16, i16, i8 u8);
+
+// i16 -> Signed9Bit
+// u16 -> Signed9Bit
+// i32 -> Signed9Bit
+// u32 -> Signed9Bit
+// i64 -> Signed9Bit
+// u64 -> Signed9Bit
+try_from_native_type_to_self!(Signed9Bit, u16, i16, i16 u16 i32 u32 i64 u64);
+
+// Signed9Bit -> i8
+// Signed9Bit -> u8
+try_from_self_to_native_type!(Signed9Bit, u16, i16, i8 u8);
+
+// Signed9Bit -> i16
+from_self_to_native_type!(Signed9Bit, u16, i16, i16);
+// Signed9Bit -> u16
+try_from_self_to_native_type!(Signed9Bit, u16, i16, u16);
+// Signed9Bit -> i32
+from_self_to_native_type!(Signed9Bit, u16, i16, i32);
+// Signed9Bit -> u32
+try_from_self_to_native_type!(Signed9Bit, u16, i16, u32);
+// Signed9Bit -> i64
+from_self_to_native_type!(Signed9Bit, u16, i16, i64);
+// Signed9Bit -> u64
+try_from_self_to_native_type!(Signed9Bit, u16, i16, u64);
+
+////////////////////////////////////////////////////////////////////////
+// Signed18Bit
+////////////////////////////////////////////////////////////////////////
+
+
+/// Signed counterpart of [`Unsigned18Bit`].
+#[derive(Clone, Copy)]
+pub struct Signed18Bit {
+    pub(crate) bits: u32,
+}
+
+// i8 -> Signed18Bit
+// u8 -> Signed18Bit
+// i16 -> Signed18Bit
+// u16 -> Signed18Bit
+from_native_type_to_self!(Signed18Bit, u32, i32, i8 u8 i16 u16);
+
+// i32 -> Signed18Bit
+// u32 -> Signed18Bit
+// i64 -> Signed18Bit
+// u64 -> Signed18Bit
+try_from_native_type_to_self!(Signed18Bit, u32, i32, i32 u32 i64 u64);
+
+// Signed18Bit -> i8
+// Signed18Bit -> u8
+// Signed18Bit -> i16
+// Signed18Bit -> u16
+try_from_self_to_native_type!(Signed18Bit, u32, i32, i8 u8 i16 u16);
+
+// Signed18Bit -> i32
+from_self_to_native_type!(Signed18Bit, u32, i32, i32);
+// Signed18Bit -> u32
+try_from_self_to_native_type!(Signed18Bit, u32, i32, u32);
+// Signed18Bit -> i64
+from_self_to_native_type!(Signed18Bit, u32, i32, i64);
+// Signed18Bit -> u64
+try_from_self_to_native_type!(Signed18Bit, u32, i32, u64);
+
+signed_ones_complement_impl!(Signed18Bit, 18, u32, i32, Unsigned18Bit);
+
+////////////////////////////////////////////////////////////////////////
+// Signed36Bit
+////////////////////////////////////////////////////////////////////////
+
+/// Signed counterpart of [`Unsigned36Bit`].
+#[derive(Clone, Copy)]
+pub struct Signed36Bit {
+    pub(crate) bits: u64,
+}
+
+// i8 -> Signed36Bit
+// u8 -> Signed36Bit
+// i16 -> Signed36Bit
+// u16 -> Signed36Bit
+// i32 -> Signed36Bit
+// u32 -> Signed36Bit
+from_native_type_to_self!(Signed36Bit, u64, i64, i8 u8 i16 u16 i32 u32);
+
+// i64 -> Signed36Bit
+// u64 -> Signed36Bit
+try_from_native_type_to_self!(Signed36Bit, u64, i64, i64 u64);
+
+// Signed36Bit -> i8
+// Signed36Bit -> u8
+// Signed36Bit -> i16
+// Signed36Bit -> u16
+// Signed36Bit -> i32
+// Signed36Bit -> u32
+try_from_self_to_native_type!(Signed36Bit, u64, i64, i8 u8 i16 u16 i32 u32);
+
+// Signed36Bit -> i64
+from_self_to_native_type!(Signed36Bit, u64, i64, i64);
+// Signed36Bit -> u64
+try_from_self_to_native_type!(Signed36Bit, u64, i64, u64);
+
+signed_ones_complement_impl!(Signed36Bit, 36, u64, i64, Unsigned36Bit);
+
+
+
+
+impl TryFrom<Unsigned18Bit> for Signed18Bit {
+    type Error = ConversionFailed;
+    fn try_from(n: Unsigned18Bit) -> Result<Self, ConversionFailed> {
+	let val: i32 = i32::from(n);
+	Signed18Bit::try_from(val)
+    }
+}
+
+impl From<Signed5Bit> for Signed18Bit {
+    fn from(n: Signed5Bit) -> Self {
+	Signed18Bit::from(i8::from(n))
+    }
+}
+
+impl From<Signed6Bit> for Signed18Bit {
+    fn from(n: Signed6Bit) -> Self {
+	Signed18Bit::from(i8::from(n))
+    }
+}
+
+impl From<Signed9Bit> for Signed18Bit {
+    fn from(n: Signed9Bit) -> Self {
+	Signed18Bit::from(i16::from(n))
+    }
+}

--- a/base/src/onescomplement/signed/tests18.rs
+++ b/base/src/onescomplement/signed/tests18.rs
@@ -1,0 +1,444 @@
+use super::{ConversionFailed, Signed18Bit};
+
+macro_rules! assert_octal_eq {
+    ($left:expr, $right:expr $(,)?) => {{
+        match (&$left, &$right) {
+            (left_val, right_val) => {
+                if !(*left_val == *right_val) {
+                    panic!(
+                        "Assertion failed: {:>#012o} != {:>#012o}",
+                        left_val, right_val
+                    );
+                }
+            }
+        }
+    }};
+}
+
+#[test]
+fn test_signed18_max_value() {
+    assert_eq!(u64::try_from(Signed18Bit::MAX), Ok(0o377_777_u64));
+    assert_eq!(u32::try_from(Signed18Bit::MAX), Ok(0o377_777_u32));
+    assert_eq!(i64::from(Signed18Bit::MAX), 0o377_777 as i64);
+    assert_eq!(i32::from(Signed18Bit::MAX), 0o377_777 as i32);
+}
+
+#[test]
+fn test_signed18_max_range() {
+    assert!(u8::try_from(Signed18Bit::MAX).is_err());
+    assert!(i8::try_from(Signed18Bit::MAX).is_err());
+}
+
+#[test]
+fn test_signed18_min_value() {
+    assert_eq!(i64::from(Signed18Bit::MIN), -(0o377_777 as i64));
+    assert_eq!(i32::from(Signed18Bit::MIN), -(0o377_777 as i32));
+}
+
+#[test]
+fn test_signed18_min_range() {
+    assert!(u64::try_from(Signed18Bit::MIN).is_err());
+    assert!(u32::try_from(Signed18Bit::MIN).is_err());
+    assert!(u16::try_from(Signed18Bit::MIN).is_err());
+    assert!(u8::try_from(Signed18Bit::MIN).is_err());
+}
+
+#[test]
+fn test_from_u8() {
+    assert_eq!(Signed18Bit::from(0_u8), Signed18Bit::ZERO);
+    assert_eq!(Signed18Bit::from(1_u8), Signed18Bit::ONE);
+    assert_eq!(Signed18Bit::from(0_u8).bits, 0_u32);
+    assert_eq!(Signed18Bit::from(1_u8).bits, 1_u32);
+    assert_eq!(Signed18Bit::from(0o377_u8).bits, 0o377_u32);
+}
+
+#[test]
+fn test_try_from_signed18bit_u8() {
+    assert_eq!(u8::try_from(Signed18Bit::ONE), Ok(1_u8));
+    assert_eq!(u8::try_from(Signed18Bit::ZERO), Ok(0_u8));
+    assert_eq!(u8::try_from(Signed18Bit::from(1_u8)), Ok(1_u8));
+    assert_eq!(u8::try_from(Signed18Bit::from(0o377_u8)), Ok(0o377_u8));
+    assert_eq!(
+        u8::try_from(Signed18Bit {
+            bits: 0b011_111_111_u32
+        }),
+        Ok(0o377_u8)
+    );
+    assert_eq!(
+        u8::try_from(Signed18Bit {
+            bits: 0o777_776_u32
+        }), // -1
+        Err(ConversionFailed::TooSmall)
+    );
+    assert_eq!(
+        u8::try_from(Signed18Bit {
+            bits: 0o777_677_u32
+        }), // -127
+        Err(ConversionFailed::TooSmall)
+    );
+}
+
+#[test]
+fn test_i8_round_tripping() {
+    let mut prev: Option<Signed18Bit> = None;
+    for i in i8::MIN..i8::MAX {
+        let q: Signed18Bit = Signed18Bit::from(i);
+        if let Some(qprev) = prev {
+            assert!(
+                q > qprev,
+                "failed to round-trip {}: {:?} should be greater than {:?}",
+                i,
+                q,
+                qprev
+            );
+        }
+        prev = Some(q);
+        match i8::try_from(q) {
+            Ok(out) => {
+                assert_eq!(i, out, "Round trip failed for {}->{:?}->{}", i, &q, out);
+            }
+            Err(e) => {
+                panic!(
+		    "Unexpected overflow when round-tripping  {}->{:?}-> [conversion to i8 failed with error {}]",
+		    i, &q, e);
+            }
+        }
+    }
+}
+
+#[test]
+fn test_i16_round_tripping() {
+    let mut prev: Option<Signed18Bit> = None;
+    for i in i16::MIN..i16::MAX {
+        let q: Signed18Bit = Signed18Bit::from(i);
+        if let Some(qprev) = prev {
+            assert!(
+                q > qprev,
+                "failed to round-trip {}: {:?} should be greater than {:?}",
+                i,
+                q,
+                qprev
+            );
+        }
+        prev = Some(q);
+        match i16::try_from(q) {
+            Ok(out) => {
+                assert_eq!(i, out, "Round trip failed for {}->{:?}->{}", i, &q, out);
+            }
+            Err(e) => {
+                panic!(
+		    "Unexpected overflow when round-tripping  {}->{:?}-> [conversion to i8 failed with error {}]",
+		    i, &q, e);
+            }
+        }
+    }
+}
+
+#[test]
+fn test_u8_round_tripping() {
+    let mut prev: Option<Signed18Bit> = None;
+    for i in u8::MIN..u8::MAX {
+        let q: Signed18Bit = Signed18Bit::from(i);
+        if let Some(qprev) = prev {
+            assert!(
+                q > qprev,
+                "failed to round-trip {}: {:?} should be greater than {:?}",
+                i,
+                q,
+                qprev
+            );
+        }
+        prev = Some(q);
+        match u8::try_from(q) {
+            Ok(out) => {
+                assert_eq!(i, out, "Round trip failed for {}->{:?}->{}", i, &q, out);
+            }
+            Err(e) => {
+                panic!(
+		    "Unexpected overflow when round-tripping  {}->{:?}-> [conversion to i8 failed with error {}]",
+		    i, &q, e);
+            }
+        }
+    }
+}
+
+#[test]
+fn test_u16_round_tripping() {
+    let mut prev: Option<Signed18Bit> = None;
+    for i in u16::MIN..u16::MAX {
+        let q: Signed18Bit = Signed18Bit::from(i);
+        if let Some(qprev) = prev {
+            assert!(
+                q > qprev,
+                "failed to round-trip {}: {:?} should be greater than {:?}",
+                i,
+                q,
+                qprev
+            );
+        }
+        prev = Some(q);
+        match u16::try_from(q) {
+            Ok(out) => {
+                assert_eq!(i, out, "Round trip failed for {}->{:?}->{}", i, &q, out);
+            }
+            Err(e) => {
+                panic!(
+		    "Unexpected overflow when round-tripping  {}->{:?}-> [conversion to i8 failed with error {}]",
+		    i, &q, e);
+            }
+        }
+    }
+}
+
+#[test]
+fn test_convert_to_ones_complement() {
+    assert_octal_eq!(Signed18Bit::convert_to_ones_complement(0_i32), 0_u32);
+    assert_octal_eq!(Signed18Bit::convert_to_ones_complement(1_i32), 1_u32);
+    assert_octal_eq!(
+        Signed18Bit::convert_to_ones_complement(-1_i32),
+        0o777_776_u32
+    );
+}
+
+#[test]
+fn test_from_i16_signed18bit() {
+    assert_octal_eq!(Signed18Bit::ZERO.bits, 0_u32);
+    assert_octal_eq!(Signed18Bit::ONE.bits, 1_u32);
+    assert_octal_eq!(Signed18Bit::from(127_i16).bits, 127_u32);
+    // octal because binary gets awkwardly long
+    // Self::bits has 1 sign
+    assert_octal_eq!(Signed18Bit::from(1_i16).bits, 0o000_001_u32); //  ( 2^0)
+    assert_octal_eq!(Signed18Bit::from(2_i16).bits, 0o000_002_u32); //  ( 2^1)
+    assert_octal_eq!(Signed18Bit::from(4_i16).bits, 0o000_004_u32); //  ( 2^2)
+    assert_octal_eq!(Signed18Bit::from(8_i16).bits, 0o000_010_u32); //  ( 2^3)
+    assert_octal_eq!(Signed18Bit::from(16_i16).bits, 0o000_020_u32); //  ( 2^4)
+    assert_octal_eq!(Signed18Bit::from(32_i16).bits, 0o000_040_u32); //  ( 2^5)
+    assert_octal_eq!(Signed18Bit::from(64_i16).bits, 0o000_100_u32); //  ( 2^6)
+    assert_octal_eq!(Signed18Bit::from(128_i16).bits, 0o000_200_u32); //  ( 2^7)
+    assert_octal_eq!(Signed18Bit::from(256_i16).bits, 0o000_400_u32); //  ( 2^8)
+    assert_octal_eq!(Signed18Bit::from(512_i16).bits, 0o001_000_u32); //  ( 2^9)
+    assert_octal_eq!(Signed18Bit::from(1024_i16).bits, 0o002_000_u32); //  (2^10)
+    assert_octal_eq!(Signed18Bit::from(2048_i16).bits, 0o004_000_u32); //  (2^11)
+    assert_octal_eq!(Signed18Bit::from(4096_i16).bits, 0o010_000_u32); //  (2^12)
+    assert_octal_eq!(Signed18Bit::from(8192_i16).bits, 0o020_000_u32); //  (2^13)
+    assert_octal_eq!(Signed18Bit::from(16384_i16).bits, 0o040_000_u32); //  (2^14)
+
+    assert_octal_eq!(Signed18Bit::from(-1_i16).bits, 0o777_776_u32); // -( 2^0)
+    assert_octal_eq!(Signed18Bit::from(-2_i16).bits, 0o777_775_u32); // -( 2^1)
+    assert_octal_eq!(Signed18Bit::from(-4_i16).bits, 0o777_773_u32); // -( 2^2)
+    assert_octal_eq!(Signed18Bit::from(-8_i16).bits, 0o777_767_u32); // -( 2^3)
+    assert_octal_eq!(Signed18Bit::from(-16_i16).bits, 0o777_757_u32); // -( 2^4)
+    assert_octal_eq!(Signed18Bit::from(-32_i16).bits, 0o777_737_u32); // -( 2^5)
+    assert_octal_eq!(Signed18Bit::from(-64_i16).bits, 0o777_677_u32); // -( 2^6)
+    assert_octal_eq!(Signed18Bit::from(-128_i16).bits, 0o777_577_u32); // -( 2^7)
+    assert_octal_eq!(Signed18Bit::from(-256_i16).bits, 0o777_377_u32); // -( 2^8)
+    assert_octal_eq!(Signed18Bit::from(-512_i16).bits, 0o776_777_u32); // -( 2^9)
+    assert_octal_eq!(Signed18Bit::from(-1024_i16).bits, 0o775_777_u32); // -(2^10)
+    assert_octal_eq!(Signed18Bit::from(-2048_i16).bits, 0o773_777_u32); // -(2^11)
+    assert_octal_eq!(Signed18Bit::from(-4096_i16).bits, 0o767_777_u32); // -(2^12)
+    assert_octal_eq!(Signed18Bit::from(-8192_i16).bits, 0o757_777_u32); // -(2^13)
+    assert_octal_eq!(Signed18Bit::from(-16384_i16).bits, 0o737_777_u32); // -(2^14)
+    assert_octal_eq!(Signed18Bit::from(-32768_i16).bits, 0o677_777_u32); // -(2^15)
+}
+
+#[test]
+fn test_from_i32_signed18bit() {
+    assert_octal_eq!(
+        Signed18Bit::try_from(32768_i32).unwrap().bits,
+        0o100_000_u32
+    );
+    assert_octal_eq!(
+        Signed18Bit::try_from(65536_i32).unwrap().bits,
+        0o200_000_u32
+    );
+}
+
+#[test]
+fn test_signed18bit_zero_values() {
+    const MINUS_ZERO: Signed18Bit = Signed18Bit {
+        bits: (1 << 18) - 1_u32,
+    };
+    assert_eq!(
+        i8::try_from(MINUS_ZERO),
+        Ok(0_i8),
+        "-0 should convert to 0_i8"
+    );
+    const PLUS_ZERO: Signed18Bit = Signed18Bit {
+        bits: 0b000_000_000_u32,
+    };
+    assert_eq!(
+        i8::try_from(PLUS_ZERO),
+        Ok(0_i8),
+        "+0 should convert to 0_i8"
+    );
+    assert_eq!(PLUS_ZERO, MINUS_ZERO); // need to implement PartialEq first.
+}
+
+#[test]
+fn test_from_signed18bit_to_i8() {
+    assert_eq!(i8::try_from(Signed18Bit::ZERO), Ok(0_i8));
+    assert_eq!(i8::try_from(Signed18Bit::ONE), Ok(1_i8));
+    assert_eq!(i8::try_from(Signed18Bit { bits: 127_u32 }), Ok(127_i8));
+    assert_eq!(
+        i8::try_from(Signed18Bit {
+            bits: 0o777_776_u32
+        }),
+        Ok(-1_i8)
+    );
+    assert_eq!(
+        i8::try_from(Signed18Bit {
+            bits: 0o777_775_u32
+        }),
+        Ok(-2_i8)
+    );
+    assert_eq!(
+        i8::try_from(Signed18Bit {
+            bits: 0o777_675_u32
+        }),
+        Ok(-66_i8)
+    );
+    assert_eq!(
+        i8::try_from(Signed18Bit {
+            bits: 0o777_600_u32
+        }),
+        Ok(-127_i8)
+    );
+    assert!(dbg!(i8::try_from(dbg!(Signed18Bit::MAX))).is_err());
+    assert!(i8::try_from(Signed18Bit::MIN).is_err());
+}
+
+#[test]
+fn test_from_signed18bit_to_i16() {
+    assert_eq!(i16::try_from(Signed18Bit::ZERO), Ok(0_i16));
+    assert_eq!(i16::try_from(Signed18Bit::ONE), Ok(1_i16));
+    assert_eq!(i16::try_from(Signed18Bit { bits: 127_u32 }), Ok(127_i16));
+    assert_eq!(
+        i16::try_from(Signed18Bit { bits: 32767_u32 }),
+        Ok(32767_i16)
+    );
+    assert!(i16::try_from(Signed18Bit::MAX).is_err());
+    assert!(i16::try_from(Signed18Bit::MIN).is_err());
+}
+
+#[test]
+fn test_from_u16_to_signed18bit() {
+    assert_eq!(Signed18Bit::try_from(0_u16), Ok(Signed18Bit::ZERO));
+    assert_eq!(Signed18Bit::try_from(1_u16), Ok(Signed18Bit::ONE));
+    assert_eq!(Signed18Bit::from(0o377_u16).bits, 0o000_000_377_u32);
+}
+
+#[test]
+fn test_from_signed18bit_to_u16() {
+    assert_eq!(u16::try_from(Signed18Bit::ZERO), Ok(0));
+    assert_eq!(u16::try_from(Signed18Bit::ONE), Ok(1));
+    assert_eq!(
+        u16::try_from(Signed18Bit { bits: 0o377_u32 }),
+        Ok(0o377_u16)
+    );
+    assert_eq!(
+        u16::try_from(Signed18Bit {
+            bits: 0o400_000_u32
+        }),
+        Err(ConversionFailed::TooSmall)
+    );
+    assert_eq!(
+        u16::try_from(Signed18Bit {
+            bits: 0o477_000_u32
+        }),
+        Err(ConversionFailed::TooSmall)
+    );
+}
+
+#[test]
+fn test_signed18bit_ord() {
+    assert!(Signed18Bit::ZERO < Signed18Bit::ONE);
+    assert!(!(Signed18Bit::ONE < Signed18Bit::ZERO));
+    assert!(!(Signed18Bit::ZERO < Signed18Bit::ZERO));
+    assert!(!(Signed18Bit::ONE < Signed18Bit::ONE));
+
+    assert!(Signed18Bit::ONE > Signed18Bit::ZERO);
+    assert!(!(Signed18Bit::ZERO > Signed18Bit::ZERO));
+    assert!(!(Signed18Bit::ONE > Signed18Bit::ONE));
+    assert!(!(Signed18Bit::ZERO > Signed18Bit::ONE));
+
+    assert!(Signed18Bit::MIN < Signed18Bit::MAX);
+    assert!(Signed18Bit::MAX > Signed18Bit::MIN);
+}
+
+#[test]
+fn test_signed18bit_eq() {
+    assert_eq!(Signed18Bit::ZERO, Signed18Bit::ZERO);
+    assert_eq!(Signed18Bit::ONE, Signed18Bit::ONE);
+
+    let another_one: Signed18Bit = Signed18Bit::from(1_i8);
+    assert_eq!(
+        Signed18Bit::ONE, another_one,
+        "ensure we don't confuse identity with equality"
+    );
+}
+
+#[test]
+fn test_signed18bit_checked_add() {
+    // Test the basics: adding zero to something leaves it unchanged.
+    assert_eq!(Signed18Bit::ZERO.checked_add(Signed18Bit::ZERO), Some(Signed18Bit::ZERO));
+    assert_eq!(Signed18Bit::ZERO.checked_add(Signed18Bit::ONE), Some(Signed18Bit::ONE));
+    assert_eq!(Signed18Bit::ONE.checked_add(Signed18Bit::ZERO), Some(Signed18Bit::ONE));
+    assert_eq!(Signed18Bit::MAX.checked_add(Signed18Bit::ZERO), Some(Signed18Bit::MAX));
+    assert_eq!(Signed18Bit::MIN.checked_add(Signed18Bit::ZERO), Some(Signed18Bit::MIN));
+
+    // Test the basics: 1+1=2
+    let two: Signed18Bit = Signed18Bit::from(2_i8);
+    assert_eq!(Signed18Bit::ONE.checked_add(Signed18Bit::ONE), Some(two));
+
+    // Verify that we correctly detect overflow
+    assert_eq!(Signed18Bit::MAX.checked_add(Signed18Bit::ONE), None);
+
+    let minus_one: Signed18Bit = Signed18Bit::from(-1_i8);
+    assert!(dbg!(minus_one) < Signed18Bit::ZERO);
+    assert_eq!(
+        i32::from(Signed18Bit::MAX.checked_add(minus_one).unwrap()),
+        0o377776_i32
+    );
+    assert_eq!(Signed18Bit::ZERO.checked_add(minus_one).unwrap(), minus_one);
+}
+
+#[test]
+fn test_signed18bit_checked_sub() {
+    let minus_one: Signed18Bit = Signed18Bit::from(-1_i8);
+
+    // Test the basics: adding zero to something leaves it unchanged.
+    assert_eq!(Signed18Bit::ZERO.checked_sub(Signed18Bit::ZERO), Some(Signed18Bit::ZERO));
+    assert_eq!(Signed18Bit::ONE.checked_sub(Signed18Bit::ZERO), Some(Signed18Bit::ONE));
+    assert_eq!(Signed18Bit::MAX.checked_sub(Signed18Bit::ZERO), Some(Signed18Bit::MAX));
+    assert_eq!(Signed18Bit::MIN.checked_sub(Signed18Bit::ZERO), Some(Signed18Bit::MIN));
+
+    // Test the basics: 2-1=1
+    let two: Signed18Bit = Signed18Bit::from(2_i8);
+    assert_eq!(two.checked_sub(Signed18Bit::ONE), Some(Signed18Bit::ONE));
+    assert_eq!(two.checked_sub(two), Some(Signed18Bit::ZERO));
+
+    // Verify that we correctly detect overflow
+    assert_eq!(Signed18Bit::MIN.checked_sub(Signed18Bit::ONE), None);
+
+    assert_eq!(
+        i32::from(Signed18Bit::MAX.checked_sub(Signed18Bit::ONE).unwrap()),
+        0o377776_i32
+    );
+    assert_eq!(Signed18Bit::ZERO.checked_sub(Signed18Bit::ONE).unwrap(), minus_one);
+}
+
+#[test]
+fn test_signed18bit_abs() {
+    let minus_one: Signed18Bit = Signed18Bit::from(-1_i8);
+    assert_eq!(Signed18Bit::ZERO, Signed18Bit::ZERO.abs());
+    assert_eq!(Signed18Bit::ONE, Signed18Bit::ONE.abs());
+    assert_eq!(Signed18Bit::ONE, minus_one.abs());
+}
+
+#[test]
+fn test_signed18bit_checked_abs() {
+    let minus_one: Signed18Bit = Signed18Bit::from(-1_i8);
+    assert_eq!((Signed18Bit::ZERO, false), Signed18Bit::ZERO.overflowing_abs());
+    assert_eq!((Signed18Bit::ONE, false), Signed18Bit::ONE.overflowing_abs());
+    assert_eq!((Signed18Bit::ONE, false), minus_one.overflowing_abs());
+}

--- a/base/src/onescomplement/signed/tests36.rs
+++ b/base/src/onescomplement/signed/tests36.rs
@@ -1,0 +1,137 @@
+use super::{ConversionFailed, Signed36Bit};
+
+macro_rules! assert_octal_eq {
+    ($left:expr, $right:expr $(,)?) => {{
+        match (&$left, &$right) {
+            (left_val, right_val) => {
+                if !(*left_val == *right_val) {
+                    panic!(
+                        "Assertion failed: {:>#012o} != {:>#012o}",
+                        left_val, right_val
+                    );
+                }
+            }
+        }
+    }};
+}
+
+#[test]
+fn test_signed36_max_value() {
+    assert_eq!(u64::try_from(Signed36Bit::MAX), Ok(0o377_777_777_777_u64));
+    assert_eq!(i64::from(Signed36Bit::MAX), 0o377_777_777_777_i64);
+}
+
+#[test]
+fn test_signed36_min_value() {
+    assert_eq!(i64::from(Signed36Bit::MIN), -0o377_777_777_777_i64);
+}
+
+#[test]
+fn test_signed36_min_range() {
+    dbg!(&Signed36Bit::MIN);
+    assert!(dbg!(u64::try_from(Signed36Bit::MIN)).is_err());
+    assert!(dbg!(u32::try_from(Signed36Bit::MIN)).is_err());
+    assert!(dbg!(u16::try_from(Signed36Bit::MIN)).is_err());
+    assert!(dbg!(u8::try_from(Signed36Bit::MIN)).is_err());
+}
+
+#[test]
+fn test_from_u8() {
+    assert_eq!(Signed36Bit::from(0_u8).bits, 0_u64);
+    assert_eq!(Signed36Bit::from(1_u8).bits, 1_u64);
+    assert_eq!(Signed36Bit::from(0o377_u8).bits, 0o377_u64);
+}
+
+#[test]
+fn test_try_from_signed36bit_u8() {
+    assert_eq!(u8::try_from(Signed36Bit::from(0_u8)), Ok(0_u8));
+    assert_eq!(u8::try_from(Signed36Bit::from(1_u8)), Ok(1_u8));
+    assert_eq!(u8::try_from(Signed36Bit::from(0o377_u8)), Ok(0o377_u8));
+    assert_eq!(u8::try_from(Signed36Bit::from(0o377_u32)), Ok(0o377_u8));
+    assert_eq!(
+        u8::try_from(Signed36Bit::from(-1_i8)),
+        Err(ConversionFailed::TooSmall)
+    );
+    assert_eq!(
+        u8::try_from(Signed36Bit::from(-127_i8)),
+        Err(ConversionFailed::TooSmall)
+    );
+}
+
+#[test]
+fn test_i16_round_tripping() {
+    let mut prev: Option<Signed36Bit> = None;
+    for i in i16::MIN..i16::MAX {
+        let q: Signed36Bit = Signed36Bit::from(i);
+        if let Some(qprev) = prev {
+            assert!(
+                q > qprev,
+                "failed to round-trip {}: {:?} should be greater than {:?}",
+                i,
+                q,
+                qprev
+            );
+        }
+        prev = Some(q);
+        match i16::try_from(q) {
+            Ok(out) => {
+                assert_eq!(i, out, "Round trip failed for {}->{:?}->{}", i, &q, out);
+            }
+            Err(e) => {
+                panic!(
+		    "Unexpected overflow when round-tripping  {}->{:?}-> [conversion to i8 failed with error {}]",
+		    i, &q, e);
+            }
+        }
+    }
+}
+
+#[test]
+fn test_convert_to_ones_complement() {
+    assert_octal_eq!(
+        Signed36Bit::convert_to_ones_complement(-1_i64),
+        0o777_777_777_776_u64
+    );
+}
+
+#[test]
+fn test_i32_round_tripping() {
+    fn round_trip(input: i32) {
+        let x = Signed36Bit::from(input);
+        let result: i32 = x.try_into().expect("round-trip should work");
+        assert_octal_eq!(input, result);
+    }
+
+    for bitpos in 0..32 {
+        let input: i32 = 1_i32 << bitpos;
+        let (negated, overflow) = input.overflowing_neg();
+        round_trip(input);
+        if !overflow {
+            round_trip(negated);
+        }
+    }
+}
+
+#[test]
+fn test_i64_round_tripping() {
+    fn round_trip(input: i64) {
+        match Signed36Bit::try_from(input) {
+            Err(_) if input >= 0 => {
+                assert!(input >= 1_i64 << 35);
+            }
+            Err(_) => {
+                assert!(input <= -(1_i64 << 35));
+            }
+            Ok(x) => {
+                let result: i64 = x.try_into().expect("round-trip should work");
+                assert_octal_eq!(input, result);
+            }
+        }
+    }
+
+    for bitpos in 0..63 {
+        let input: i64 = 1_i64 << bitpos;
+        round_trip(input);
+        round_trip(-input);
+    }
+}

--- a/base/src/onescomplement/signed/tests5.rs
+++ b/base/src/onescomplement/signed/tests5.rs
@@ -1,0 +1,138 @@
+use super::Signed5Bit;
+
+#[test]
+fn test_from_u8() {
+    assert_eq!(u8::try_from(Signed5Bit::try_from(1_u8).unwrap()), Ok(1_u8)); // 2^0
+    assert_eq!(u8::try_from(Signed5Bit::try_from(2_u8).unwrap()), Ok(2_u8)); // 2^1
+    assert_eq!(u8::try_from(Signed5Bit::try_from(4_u8).unwrap()), Ok(4_u8)); // 2^2
+    assert_eq!(u8::try_from(Signed5Bit::try_from(8_u8).unwrap()), Ok(8_u8)); // 2^3
+    assert!(dbg!(Signed5Bit::try_from(16_u8)).is_err());
+}
+
+#[test]
+fn test_i8_round_tripping() {
+    let mut prev: Option<Signed5Bit> = None;
+    for i in -15_i8..15_i8 {
+        let q: Signed5Bit = Signed5Bit::try_from(i).expect("input is in range");
+        if let Some(qprev) = prev {
+            assert!(
+                q > qprev,
+                "failed to round-trip {}: {:?} should be greater than {:?}",
+                i,
+                q,
+                qprev
+            );
+        }
+        prev = Some(q);
+        let out = i8::from(q);
+        assert_eq!(i, out, "Round trip failed for {}->{:?}->{}", i, &q, out);
+    }
+}
+
+#[test]
+fn test_signed5bit_ord() {
+    let zero: Signed5Bit = Signed5Bit::try_from(0_i8).unwrap();
+    let one: Signed5Bit = Signed5Bit::try_from(1_i8).unwrap();
+    assert!(zero < one);
+    assert!(!(one < zero));
+    assert!(!(zero < zero));
+    assert!(!(one < one));
+
+    assert!(one > zero);
+    assert!(!(zero > zero));
+    assert!(!(one > one));
+    assert!(!(zero > one));
+
+    assert!(Signed5Bit::MIN < Signed5Bit::MAX);
+    assert!(Signed5Bit::MAX > Signed5Bit::MIN);
+}
+
+#[test]
+fn test_signed5bit_eq() {
+    let zero: Signed5Bit = Signed5Bit::try_from(0_i8).unwrap();
+    let one: Signed5Bit = Signed5Bit::try_from(1_i8).unwrap();
+    assert_eq!(zero, zero);
+    assert_eq!(one, one);
+
+    let another_one: Signed5Bit = Signed5Bit::try_from(1_i8).unwrap();
+    assert_eq!(
+        one, another_one,
+        "ensure we don't confuse identy with equality"
+    );
+}
+
+#[test]
+fn test_signed5bit_checked_add() {
+    let zero: Signed5Bit = Signed5Bit::try_from(0_i8).unwrap();
+    let one: Signed5Bit = Signed5Bit::try_from(1_i8).unwrap();
+
+    // Test the basics: adding zero to something leaves it unchanged.
+    assert_eq!(zero.checked_add(zero), Some(zero));
+    assert_eq!(zero.checked_add(one), Some(one));
+    assert_eq!(one.checked_add(zero), Some(one));
+    assert_eq!(Signed5Bit::MAX.checked_add(zero), Some(Signed5Bit::MAX));
+    assert_eq!(Signed5Bit::MIN.checked_add(zero), Some(Signed5Bit::MIN));
+
+    // Test the basics: 1+1=2
+    let two: Signed5Bit = Signed5Bit::try_from(2_i8).unwrap();
+    assert_eq!(one.checked_add(one), Some(two));
+
+    // Verify that we correctly detect overflow
+    assert_eq!(Signed5Bit::MAX.checked_add(one), None);
+
+    let minus_one: Signed5Bit = Signed5Bit::try_from(-1_i8).unwrap();
+    assert!(dbg!(minus_one) < zero);
+
+    // The max value is 15, so subtracting 1 from that shoudl give 14.
+    let max: i8 = i8::from(Signed5Bit::MAX);
+    assert_eq!(max, 15);
+    assert_eq!(
+        i8::from(Signed5Bit::MAX.checked_add(minus_one).unwrap()),
+        14_i8
+    );
+
+    assert_eq!(zero.checked_add(minus_one).unwrap(), minus_one);
+}
+
+#[test]
+fn test_signed5bit_checked_sub() {
+    let zero: Signed5Bit = Signed5Bit::try_from(0_i8).unwrap();
+    let one: Signed5Bit = Signed5Bit::try_from(1_i8).unwrap();
+    let minus_one: Signed5Bit = Signed5Bit::try_from(-1_i8).unwrap();
+
+    // Test the basics: adding zero to something leaves it unchanged.
+    assert_eq!(zero.checked_sub(zero), Some(zero));
+    assert_eq!(one.checked_sub(zero), Some(one));
+    assert_eq!(Signed5Bit::MAX.checked_sub(zero), Some(Signed5Bit::MAX));
+    assert_eq!(Signed5Bit::MIN.checked_sub(zero), Some(Signed5Bit::MIN));
+
+    // Test the basics: 2-1=1
+    let two: Signed5Bit = Signed5Bit::try_from(2_i8).unwrap();
+    assert_eq!(two.checked_sub(one), Some(one));
+    assert_eq!(two.checked_sub(two), Some(zero));
+
+    // Verify that we correctly detect overflow
+    assert_eq!(Signed5Bit::MIN.checked_sub(one), None);
+
+    assert_eq!(zero.checked_sub(one).unwrap(), minus_one);
+}
+
+#[test]
+fn test_signed5bit_abs() {
+    let zero: Signed5Bit = Signed5Bit::try_from(0_i8).unwrap();
+    let one: Signed5Bit = Signed5Bit::try_from(1_i8).unwrap();
+    let minus_one: Signed5Bit = Signed5Bit::try_from(-1_i8).unwrap();
+    assert_eq!(zero, zero.abs());
+    assert_eq!(one, one.abs());
+    assert_eq!(one, minus_one.abs());
+}
+
+#[test]
+fn test_signed5bit_checked_abs() {
+    let zero: Signed5Bit = Signed5Bit::try_from(0_i8).unwrap();
+    let one: Signed5Bit = Signed5Bit::try_from(1_i8).unwrap();
+    let minus_one: Signed5Bit = Signed5Bit::try_from(-1_i8).unwrap();
+    assert_eq!((zero, false), zero.overflowing_abs());
+    assert_eq!((one, false), one.overflowing_abs());
+    assert_eq!((one, false), minus_one.overflowing_abs());
+}

--- a/base/src/onescomplement/signed/tests9.rs
+++ b/base/src/onescomplement/signed/tests9.rs
@@ -1,0 +1,343 @@
+use super::{ConversionFailed, Signed9Bit};
+
+macro_rules! assert_octal_eq {
+    ($left:expr, $right:expr $(,)?) => {{
+        match (&$left, &$right) {
+            (left_val, right_val) => {
+                if !(*left_val == *right_val) {
+                    panic!(
+                        "Assertion failed: {:>#012o} != {:>#012o}",
+                        left_val, right_val
+                    );
+                }
+            }
+        }
+    }};
+}
+
+#[test]
+fn test_from_u8() {
+    assert_eq!(Signed9Bit::from(0_u8).bits, 0_u16);
+    assert_eq!(Signed9Bit::from(1_u8).bits, 1_u16);
+    assert_eq!(Signed9Bit::from(0o377_u8).bits, 0o377_u16);
+}
+
+#[test]
+fn test_try_from_signed9bit_u8() {
+    assert_eq!(u8::try_from(Signed9Bit::from(0_u8)), Ok(0_u8));
+    assert_eq!(u8::try_from(Signed9Bit::from(1_u8)), Ok(1_u8));
+    assert_eq!(u8::try_from(Signed9Bit::from(0o377_u8)), Ok(0o377_u8));
+    assert_eq!(
+        u8::try_from(Signed9Bit {
+            bits: 0b011_111_111_u16
+        }),
+        Ok(0o377_u8)
+    );
+    assert_eq!(
+        u8::try_from(Signed9Bit {
+            bits: 0b111_111_110_u16
+        }), // -1
+        Err(ConversionFailed::TooSmall)
+    );
+    assert_eq!(
+        u8::try_from(Signed9Bit {
+            bits: 0b110_000_000_u16
+        }), // -127
+        Err(ConversionFailed::TooSmall)
+    );
+}
+
+#[test]
+fn test_i8_round_tripping() {
+    let mut prev: Option<Signed9Bit> = None;
+    for i in i8::MIN..i8::MAX {
+        let q: Signed9Bit = Signed9Bit::from(i);
+        if let Some(qprev) = prev {
+            assert!(
+                q > qprev,
+                "failed to round-trip {}: {:?} should be greater than {:?}",
+                i,
+                q,
+                qprev
+            );
+        }
+        prev = Some(q);
+        match i8::try_from(q) {
+            Ok(out) => {
+                assert_eq!(i, out, "Round trip failed for {}->{:?}->{}", i, &q, out);
+            }
+            Err(e) => {
+                panic!(
+		    "Unexpected overflow when round-tripping  {}->{:?}-> [conversion to i8 failed with error {}]",
+		    i, &q, e);
+            }
+        }
+    }
+}
+
+#[test]
+fn test_u8_round_tripping() {
+    let mut prev: Option<Signed9Bit> = None;
+    for i in u8::MIN..u8::MAX {
+        let q: Signed9Bit = Signed9Bit::from(i);
+        if let Some(qprev) = prev {
+            assert!(
+                q > qprev,
+                "failed to round-trip {}: {:?} should be greater than {:?}",
+                i,
+                q,
+                qprev
+            );
+        }
+        prev = Some(q);
+        match u8::try_from(q) {
+            Ok(out) => {
+                assert_eq!(i, out, "Round trip failed for {}->{:?}->{}", i, &q, out);
+            }
+            Err(e) => {
+                panic!(
+		    "Unexpected overflow when round-tripping  {}->{:?}-> [conversion to i8 failed with error {}]",
+		    i, &q, e);
+            }
+        }
+    }
+}
+
+#[test]
+fn test_try_from_i8_signed9bit() {
+    assert_octal_eq!(Signed9Bit::from(0_i8).bits, 0_u16);
+    assert_octal_eq!(Signed9Bit::from(1_i8).bits, 1_u16);
+    assert_octal_eq!(Signed9Bit::from(127_i8).bits, 127_u16);
+    assert_octal_eq!(Signed9Bit::from(-1_i8).bits, 0b111_111_110_u16);
+    assert_octal_eq!(Signed9Bit::from(-2_i8).bits, 0b111_111_101_u16);
+    assert_octal_eq!(Signed9Bit::from(-8_i8).bits, 0b111_110_111_u16);
+    assert_octal_eq!(Signed9Bit::from(-32_i8).bits, 0b111_011_111_u16);
+    assert_octal_eq!(Signed9Bit::from(-64_i8).bits, 0b110_111_111_u16);
+    assert_octal_eq!(Signed9Bit::from(-65_i8).bits, 0b110_111_110_u16);
+    assert_octal_eq!(Signed9Bit::from(-66_i8).bits, 0b110_111_101_u16);
+    assert_octal_eq!(Signed9Bit::from(-127_i8).bits, 0b110_000_000_u16);
+    assert_octal_eq!(Signed9Bit::from(-128_i8).bits, 0b101_111_111_u16);
+}
+
+#[test]
+fn test_signed9bit_zero_values() {
+    const MINUS_ZERO: Signed9Bit = Signed9Bit {
+        bits: 0b111_111_111_u16,
+    };
+    assert_eq!(
+        i8::try_from(MINUS_ZERO),
+        Ok(0_i8),
+        "-0 should convert to 0_i8"
+    );
+    const PLUS_ZERO: Signed9Bit = Signed9Bit {
+        bits: 0b000_000_000_u16,
+    };
+    assert_eq!(
+        i8::try_from(PLUS_ZERO),
+        Ok(0_i8),
+        "+0 should convert to 0_i8"
+    );
+    // assert_eq!(PLUS_ZERO, MINUS_ZERO);   // need to implement PartialEq first.
+}
+
+#[test]
+fn test_from_signed9bit_to_i8() {
+    assert_eq!(i8::try_from(Signed9Bit { bits: 0 }), Ok(0_i8));
+    assert_eq!(i8::try_from(Signed9Bit { bits: 1 }), Ok(1_i8));
+    assert_eq!(i8::try_from(Signed9Bit { bits: 127_u16 }), Ok(127_i8));
+    assert_eq!(
+        i8::try_from(Signed9Bit {
+            bits: 0b111_111_110_u16
+        }),
+        Ok(-1_i8)
+    );
+    assert_eq!(
+        i8::try_from(Signed9Bit {
+            bits: 0b111_111_101_u16
+        }),
+        Ok(-2_i8)
+    );
+    assert_eq!(
+        i8::try_from(Signed9Bit {
+            bits: 0b110_111_101_u16
+        }),
+        Ok(-66_i8)
+    );
+    assert_eq!(
+        i8::try_from(Signed9Bit {
+            bits: 0b110_000_000_u16
+        }),
+        Ok(-127_i8)
+    );
+    assert!(i8::try_from(Signed9Bit::MAX).is_err());
+    assert!(i8::try_from(Signed9Bit::MIN).is_err());
+}
+
+#[test]
+fn test_from_u16_to_signed9bit() {
+    assert_octal_eq!(Signed9Bit::try_from(0_u16).unwrap().bits, 0_u16);
+    assert_octal_eq!(Signed9Bit::try_from(1_u16).unwrap().bits, 1_u16);
+    assert_octal_eq!(
+        Signed9Bit::try_from(0o377_u16).unwrap().bits,
+        0o000_000_377_u16
+    );
+    assert!(Signed9Bit::try_from(0o400_u16).is_err());
+}
+
+#[test]
+fn test_from_signed9bit_to_u16() {
+    assert_eq!(u16::try_from(Signed9Bit { bits: 0 }), Ok(0));
+    assert_eq!(u16::try_from(Signed9Bit { bits: 1 }), Ok(1));
+    assert_eq!(u16::try_from(Signed9Bit { bits: 0o377_u16 }), Ok(0o377_u16));
+    assert_eq!(
+        u16::try_from(Signed9Bit { bits: 0o400_u16 }),
+        Err(ConversionFailed::TooSmall)
+    );
+    assert_eq!(
+        u16::try_from(Signed9Bit { bits: 0o477_u16 }),
+        Err(ConversionFailed::TooSmall)
+    );
+}
+
+#[test]
+fn test_signed9bit_ord() {
+    let zero: Signed9Bit = Signed9Bit::from(0_i8);
+    let one: Signed9Bit = Signed9Bit::from(1_i8);
+    assert!(zero < one);
+    assert!(!(one < zero));
+    assert!(!(zero < zero));
+    assert!(!(one < one));
+
+    assert!(one > zero);
+    assert!(!(zero > zero));
+    assert!(!(one > one));
+    assert!(!(zero > one));
+
+    assert!(Signed9Bit::MIN < Signed9Bit::MAX);
+    assert!(Signed9Bit::MAX > Signed9Bit::MIN);
+}
+
+#[test]
+fn test_signed9bit_eq() {
+    let zero: Signed9Bit = Signed9Bit::from(0_i8);
+    let one: Signed9Bit = Signed9Bit::from(1_i8);
+    assert_eq!(zero, zero);
+    assert_eq!(one, one);
+
+    let another_one: Signed9Bit = Signed9Bit::from(1_i8);
+    assert_eq!(
+        one, another_one,
+        "ensure we don't confuse identy with equality"
+    );
+}
+
+#[test]
+fn test_signed9bit_checked_add() {
+    let zero: Signed9Bit = Signed9Bit::from(0_i8);
+    let one: Signed9Bit = Signed9Bit::from(1_i8);
+
+    // Test the basics: adding zero to something leaves it unchanged.
+    assert_eq!(zero.checked_add(zero), Some(zero));
+    assert_eq!(zero.checked_add(one), Some(one));
+    assert_eq!(one.checked_add(zero), Some(one));
+    assert_eq!(Signed9Bit::MAX.checked_add(zero), Some(Signed9Bit::MAX));
+    assert_eq!(Signed9Bit::MIN.checked_add(zero), Some(Signed9Bit::MIN));
+
+    // Test the basics: 1+1=2
+    let two: Signed9Bit = Signed9Bit::from(2_i8);
+    assert_eq!(one.checked_add(one), Some(two));
+
+    // Verify that we correctly detect overflow
+    assert_eq!(Signed9Bit::MAX.checked_add(one), None);
+
+    let minus_one: Signed9Bit = Signed9Bit::from(-1_i8);
+    assert!(dbg!(minus_one) < zero);
+    assert_eq!(
+        i16::from(Signed9Bit::MAX.checked_add(minus_one).unwrap()),
+        254_i16
+    );
+    assert_eq!(zero.checked_add(minus_one).unwrap(), minus_one);
+}
+
+#[test]
+fn test_signed9bit_checked_sub() {
+    let zero: Signed9Bit = Signed9Bit::from(0_i8);
+    let one: Signed9Bit = Signed9Bit::from(1_i8);
+    let minus_one: Signed9Bit = Signed9Bit::from(-1_i8);
+
+    // Test the basics: adding zero to something leaves it unchanged.
+    assert_eq!(zero.checked_sub(zero), Some(zero));
+    assert_eq!(one.checked_sub(zero), Some(one));
+    assert_eq!(Signed9Bit::MAX.checked_sub(zero), Some(Signed9Bit::MAX));
+    assert_eq!(Signed9Bit::MIN.checked_sub(zero), Some(Signed9Bit::MIN));
+
+    // Test the basics: 2-1=1
+    let two: Signed9Bit = Signed9Bit::from(2_i8);
+    assert_eq!(two.checked_sub(one), Some(one));
+    assert_eq!(two.checked_sub(two), Some(zero));
+
+    // Verify that we correctly detect overflow
+    assert_eq!(Signed9Bit::MIN.checked_sub(one), None);
+
+    assert_eq!(
+        i16::from(Signed9Bit::MAX.checked_sub(one).unwrap()),
+        254_i16
+    );
+    assert_eq!(zero.checked_sub(one).unwrap(), minus_one);
+}
+
+#[test]
+fn test_signed9bit_abs() {
+    let zero: Signed9Bit = Signed9Bit::from(0_i8);
+    let one: Signed9Bit = Signed9Bit::from(1_i8);
+    let minus_one: Signed9Bit = Signed9Bit::from(-1_i8);
+    assert_eq!(zero, zero.abs());
+    assert_eq!(one, one.abs());
+    assert_eq!(one, minus_one.abs());
+}
+
+#[test]
+fn test_signed9bit_checked_abs() {
+    let zero: Signed9Bit = Signed9Bit::from(0_i8);
+    let one: Signed9Bit = Signed9Bit::from(1_i8);
+    let minus_one: Signed9Bit = Signed9Bit::from(-1_i8);
+    assert_eq!((zero, false), zero.overflowing_abs());
+    assert_eq!((one, false), one.overflowing_abs());
+    assert_eq!((one, false), minus_one.overflowing_abs());
+}
+
+#[test]
+fn test_wrapping_add() {
+    for left in -255_i16..255_i16 {
+	for right in -255_i16..255_i16 {
+	    let expected = left.wrapping_add(right);
+	    let expected = i16::from(Signed9Bit::try_from(expected % 256).unwrap());
+
+	    let left_operand = Signed9Bit::try_from(left).unwrap();
+	    let right_operand = Signed9Bit::try_from(right).unwrap();
+	    let got = i16::from(left_operand.wrapping_add(right_operand));
+
+	    assert_eq!(expected, got,
+		       "Expected {} + {} = {}, got {:?} + {:?} = {}",
+		       left, right, expected, left_operand, right_operand, got);
+	}
+    }
+}
+
+#[test]
+fn test_wrapping_sub() {
+    for left in -255_i16..255_i16 {
+	for right in -255_i16..255_i16 {
+	    let expected = left.wrapping_sub(right);
+	    let expected = i16::from(Signed9Bit::try_from(expected % 256).unwrap());
+
+	    let left_operand = Signed9Bit::try_from(left).unwrap();
+	    let right_operand = Signed9Bit::try_from(right).unwrap();
+	    let got = i16::from(left_operand.wrapping_sub(right_operand));
+
+	    assert_eq!(expected, got,
+		       "Expected {} + {} = {}, got {:?} + {:?} = {}",
+		       left, right, expected, left_operand, right_operand, got);
+	}
+    }
+}

--- a/base/src/onescomplement/unsigned/mod.rs
+++ b/base/src/onescomplement/unsigned/mod.rs
@@ -1,0 +1,608 @@
+//! This is an implementation of unsigned types of various bit
+//! widths which accompanies the SignedXXBit one's-complement types.
+//! Since these types are unsigned, there is no sign bit and they
+//! aren't really one's-complement types.  But the interface to these
+//! is mostly similar to that of the signed (real one's-complement)
+//! types.
+
+use std::cmp::Ordering;
+use std::fmt::{self, Debug, Display, Formatter, Octal};
+use std::hash::{Hash, Hasher};
+
+use super::error::ConversionFailed;
+use super::{Sign, WordCommon};
+use super::signed::*;
+
+#[cfg(test)]
+mod tests;
+
+/// This macro implements conversions from native types to Unsigned*Bit
+/// which are always possible (e.g. From<u8> for Unsigned9Bit).
+macro_rules! from_native_type_to_self {
+    ($SelfT:ty, $($from:ty)*) => {
+	$(
+	    impl From<$from> for $SelfT {
+		fn from(n: $from) -> Self {
+		    Self {
+			bits: n.into(),
+		    }
+		}
+	    }
+	)*
+    }
+}
+
+/// This macro implements conversions from Unsigned*Bit to native
+/// types which are always possible (e.g. From<Unsigned9Bit> for i16).
+macro_rules! from_self_to_native_type {
+    ($SelfT:ty, $($to:ty)*) => {
+	$(
+	    impl From<$SelfT> for $to {
+		fn from(n: $SelfT) -> $to {
+		    // Note that $InnerT for Unsigned9Bit is u16, and
+		    // from_self_to_native_type is called with $to =
+		    // i16, because the limits of Unsigned9Bit are
+		    // wholly inside the limits of i16.  However,
+		    // since some u16 values call outside the range of
+		    // i16, we cannot use .into() here.  That is, we
+		    // know more about the range of values n.bits can
+		    // take than te compiler knows).
+		    n.bits as $to
+		}
+	    }
+	)*
+    }
+}
+
+/// This macro implements conversions from Unsigned*Bit to native
+/// types where the conversion may not always fit.  For example
+/// TryFrom<Unsigned18Bit> for u8.
+macro_rules! try_from_self_to_native_type {
+    ($SelfT:ty, $($to:ty)*) => {
+	$(
+	    impl TryFrom<$SelfT> for $to {
+		type Error = ConversionFailed;
+		fn try_from(n: $SelfT) -> Result<$to, ConversionFailed> {
+		    <$to>::try_from(n.bits).map_err(|_| ConversionFailed::TooLarge)
+		}
+	    }
+	)*
+    }
+}
+
+/// This macro implements a conversions from native types to
+/// Unsigned*Bit where the conversion may not always fit.  For example
+/// TryFrom<u64> for Unsigned36Bit.
+macro_rules! try_from_native_type_to_self {
+    ($SelfT:ty, $InnerT:ty, $($from:ty)*) => {
+	$(
+	    impl TryFrom<$from> for $SelfT {
+		type Error = ConversionFailed;
+		fn try_from(n: $from) -> Result<Self, ConversionFailed> {
+		    let bits: $InnerT = match n.try_into() {
+			Err(_) => {
+			    // Because $InnerT is unsigned, we know
+			    // that n < 0 is always an error case.
+			    // Since this macro also gets used for
+			    // conversions from unsigned types,
+			    // sometimes this conditional is useless
+			    // (and we expect it to be optimized
+			    // away).
+			    #[allow(unused_comparisons)]
+			    if n < 0 {
+				return Err(ConversionFailed::TooSmall);
+			    } else {
+				return Err(ConversionFailed::TooLarge);
+			    }
+			}
+			Ok(value) if value > Self::VALUE_BITS => {
+			    return Err(ConversionFailed::TooLarge);
+			}
+			Ok(value) => value,
+		    };
+		    Ok(
+			Self {
+			    bits,
+			}
+		    )
+		}
+	    }
+	)*
+    }
+}
+
+/// This macro implements the base functionality of the unsigned
+/// types.  The `SelfT` argument is the name of the (unsigned in this
+/// case) type we are defining.  `BITS` is the bit width of the type
+/// we are defining.  `InnerT` is the name of the native type which
+/// will store those bits.  `SignedPeerT` is the name of the
+/// equivalent signed type having the same width (e.g. for
+/// `Unsigned18Bit` this should be `Signed`8Bit`).
+macro_rules! unsigned_ones_complement_impl {
+    ($SelfT:ty, $BITS:expr, $InnerT:ty, $SignedPeerT:ty) => {
+        impl $SelfT {
+	    const MODULUS: $InnerT = (1 << $BITS);
+            const VALUE_BITS: $InnerT = Self::MODULUS - 1;
+
+            pub const MAX: Self = Self {
+                bits: Self::MODULUS - 1,
+            };
+
+            pub const ZERO: Self = Self { bits: 0 };
+	    pub const ONE: Self = Self { bits: 1 };
+            pub const MIN: Self = Self::ZERO;
+
+            pub const fn is_zero(&self) -> bool {
+                self.bits == 0
+            }
+
+            pub const fn is_negative(&self) -> bool {
+                false
+            }
+
+            pub const fn is_positive(&self) -> bool {
+                true
+            }
+
+	    pub const fn reinterpret_as_signed(&self) -> $SignedPeerT {
+		type T = $SignedPeerT;
+		T {
+		    bits: self.bits
+		}
+	    }
+
+            pub fn wrapping_add(self, rhs: $SelfT) -> $SelfT {
+                let left = <$InnerT>::from(self);
+                let right = <$InnerT>::from(rhs);
+		let in_range_value: $InnerT = left.wrapping_add(right) & Self::VALUE_BITS;
+                Self::try_from(in_range_value).unwrap()
+            }
+
+            pub fn wrapping_sub(self, rhs: $SelfT) -> $SelfT {
+                let left = <$InnerT>::from(self);
+                let right = <$InnerT>::from(rhs);
+                let in_range_value = (left + Self::MODULUS).wrapping_sub(right) & Self::VALUE_BITS;
+                Self::try_from(in_range_value).unwrap()
+            }
+
+            pub fn checked_add(self, rhs: $SelfT) -> Option<$SelfT> {
+                let left = <$InnerT>::from(self);
+                let right = <$InnerT>::from(rhs);
+                match left.checked_add(right) {
+                    Some(result) => Self::try_from(result).ok(),
+                    None => None,
+                }
+            }
+
+            pub fn checked_sub(self, rhs: $SelfT) -> Option<$SelfT> {
+                let left = <$InnerT>::from(self);
+                let right = <$InnerT>::from(rhs);
+                match left.checked_sub(right) {
+                    Some(result) => Self::try_from(result).ok(),
+                    None => None,
+                }
+            }
+
+            pub const fn abs(self) -> Self {
+                self
+            }
+
+            pub const fn overflowing_abs(self) -> (Self, bool) {
+                (self, false)
+            }
+
+            // We cannot call std::ops::And in a const because trait
+            // methods cannot be const.  So we have this work-alike in
+            // impl, since it can be called in a const context.
+            pub const fn and(self, mask: $InnerT) -> Self {
+                Self {
+                    bits: self.bits & mask,
+                }
+            }
+        }
+
+        impl WordCommon for $SelfT {
+            fn signum(&self) -> Sign {
+                if self.is_zero() {
+                    Sign::Zero
+                } else if self.is_negative() {
+                    Sign::Negative
+                } else {
+                    Sign::Positive
+                }
+            }
+        }
+
+        impl Default for $SelfT {
+            fn default() -> Self {
+                Self { bits: 0 }
+            }
+        }
+
+        impl Display for $SelfT {
+            fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+                Octal::fmt(&self.bits, f)
+            }
+        }
+
+        impl Octal for $SelfT {
+            fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+                Octal::fmt(&self.bits, f)
+            }
+        }
+
+        impl Debug for $SelfT {
+            fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+                write!(f, concat!(stringify!($SelfT), "{{bits: {:#o}}}"), self.bits)
+            }
+        }
+
+        impl Hash for $SelfT {
+            fn hash<H>(&self, state: &mut H)
+            where
+                H: Hasher,
+            {
+                self.bits.hash(state)
+            }
+        }
+
+        impl<T> PartialEq<T> for $SelfT
+        where
+            T: TryInto<$SelfT> + Copy,
+        {
+            fn eq(&self, other: &T) -> bool {
+                let converted: Result<$SelfT, _> = (*other).try_into();
+                if let Ok(rhs) = converted {
+                    match self.cmp(&rhs) {
+                        Ordering::Equal => true,
+                        _ => false,
+                    }
+                } else {
+                    false
+                }
+            }
+        }
+
+        impl Eq for $SelfT {}
+
+        impl PartialOrd<$SelfT> for $SelfT {
+            fn partial_cmp(&self, other: &$SelfT) -> Option<Ordering> {
+                Some(self.cmp(other))
+            }
+        }
+
+        impl PartialOrd<u32> for $SelfT {
+            fn partial_cmp(&self, other: &u32) -> Option<Ordering> {
+                match <$SelfT>::try_from(*other) {
+                    Ok(value) => Some(self.cmp(&value)),
+                    // The error case tells us that `other` doesn't fit
+                    // into $SelfT, so `other` must be greater.
+                    Err(_) => Some(Ordering::Less),
+                }
+            }
+        }
+
+        impl PartialOrd<u64> for $SelfT {
+            fn partial_cmp(&self, other: &u64) -> Option<Ordering> {
+                match <$SelfT>::try_from(*other) {
+                    Ok(value) => Some(self.cmp(&value)),
+                    // The error case tells us that `other` doesn't fit
+                    // into $SelfT, so `other` must be greater.
+                    Err(_) => Some(Ordering::Less),
+                }
+            }
+        }
+
+        impl Ord for $SelfT {
+            fn cmp(&self, other: &$SelfT) -> Ordering {
+                // We perform conversion here so that -0 == +0.
+                let lhs = <$InnerT>::from(*self);
+                let rhs = <$InnerT>::from(*other);
+                lhs.cmp(&rhs)
+            }
+        }
+
+        impl std::ops::Not for $SelfT {
+            type Output = Self;
+            fn not(self) -> Self {
+                Self {
+                    bits: (!self.bits) & Self::VALUE_BITS,
+                }
+            }
+        }
+
+        impl std::ops::BitAnd<$InnerT> for $SelfT {
+            type Output = Self;
+            fn bitand(self, mask: $InnerT) -> Self {
+                Self {
+                    bits: self.bits & mask,
+                }
+            }
+        }
+
+        impl std::ops::BitAnd<$SelfT> for $SelfT {
+            type Output = Self;
+            fn bitand(self, rhs: Self) -> Self {
+                self.bitand(rhs.bits)
+            }
+        }
+
+        impl std::ops::BitOr<$InnerT> for $SelfT {
+            type Output = Self;
+            fn bitor(self, mask: $InnerT) -> Self {
+                Self {
+                    bits: self.bits | mask,
+                }
+            }
+        }
+
+        impl std::ops::BitOr for $SelfT {
+            type Output = Self;
+            fn bitor(self, rhs: Self) -> Self {
+                self.bitor(rhs.bits)
+            }
+        }
+
+        impl std::ops::Shr<$SelfT> for $SelfT {
+            type Output = $SelfT;
+            fn shr(self, rhs: Self) -> Self {
+                let shift_by = rhs.bits % $BITS;
+                // Compute a mask which has a 1 in the positions which
+                // we're about to shift off the right of the word.
+                let goners_mask: $InnerT = (1 << shift_by) - 1;
+
+                // Preserve the bits we're about to shift off the
+                // right-hand side.  Although shr() will shift them
+                // back onto the most-significant end of the value,
+                // these are in the wrong position in the word (as
+                // self.bits, being wider than the value we are
+                // representing, has bits which are ignored).
+                let saved = (self.bits & goners_mask) << ($BITS - shift_by);
+
+                let bits = (self.bits.shr(shift_by) | saved) & Self::VALUE_BITS;
+                Self { bits }
+            }
+        }
+
+        impl std::ops::Shr<u32> for $SelfT {
+            type Output = $SelfT;
+            fn shr(self, shift_by: u32) -> Self {
+                // Compute a mask which has a 1 in the positions which
+                // we're about to shift off the right of the word.
+                let goners_mask: $InnerT = (1 << shift_by) - 1;
+
+                // Preserve the bits we're about to shift off the
+                // right-hand side.  Although shr() will shift them
+                // back onto the most-significant end of the value,
+                // these are in the wrong position in the word (as
+                // self.bits, being wider than the value we are
+                // representing, has bits which are ignored).
+                let saved = (self.bits & goners_mask) << ($BITS - shift_by);
+
+                let bits = (self.bits.shr(shift_by) | saved) & Self::VALUE_BITS;
+                Self { bits }
+            }
+        }
+
+        impl std::ops::Shl<$SelfT> for $SelfT {
+            type Output = $SelfT;
+            fn shl(self, shift_by: $SelfT) -> Self {
+		// Clippy is suspicious of the use of the modulus
+		// operation, but this lint check is really intended
+		// to detect things like subtractions inside an add
+		// operation.
+		#[allow(clippy::suspicious_arithmetic_impl)]
+                let shift: u32 = (shift_by.bits % $BITS) as u32;
+                self.shl(shift)
+            }
+        }
+
+        impl std::ops::Shl<u32> for $SelfT {
+            type Output = $SelfT;
+            fn shl(self, rhs: u32) -> Self {
+                let shift_by = rhs % $BITS;
+                // `goners_mask` has a 1 in the positions which we're
+                // about to shift off the left of the word.
+                let mask: $InnerT = (1 << shift_by) - 1; // correct size, wrong position
+                let goners_mask: $InnerT = mask << ($BITS - shift_by); // correct size+pos
+
+                // Preserve the bits we're about to shift off the
+                // left-hand side.  Although shl() will shift bits
+                // back onto the least-significant end of the value,
+                // the bits shifted there are the previous top bits of
+                // self.bits, but the top bits of self.bits aren't
+                // part of the value of `self`, since `self.bits` has
+                // a width greater than $BITS.
+                let saved = (self.bits & goners_mask) >> ($BITS - shift_by);
+                let bits = ((self.bits << shift_by) | saved) & Self::VALUE_BITS;
+                Self { bits }
+            }
+        }
+    };
+}
+
+/// `Unsigned5Bit` is used as a system configuration value; that is,
+/// an index into F-memory.
+#[derive(Clone, Copy)]
+pub struct Unsigned5Bit {
+    pub(crate) bits: u8,
+}
+
+/// `Unsigned6Bit` is used as an X-register address. That is, the `j`
+/// in `Xj`.
+#[derive(Clone, Copy)]
+pub struct Unsigned6Bit {
+    pub(crate) bits: u8,
+}
+
+/// `Unsigned9Bit` is the value of a "quarter" of the 36-bit TX-2
+/// machine word.  A number of instructions - and in particular the
+/// Exchange Unit - work on the quarters of a word.
+#[derive(Clone, Copy)]
+pub struct Unsigned9Bit {
+    pub(crate) bits: u16,
+}
+
+/// `Unsigned18Bit` is the value of a "half" of the 36-bit TX-2
+/// machine word.  We use this type to hold STUV-memory addresses,
+/// among other things.  Physical memory addresses though are only 17
+/// bits wide.  The remaining bit can be used to "mark" an address
+/// either for tracing (when it's an instruction address) or for
+/// deferred addressing (when it's an operand address).
+#[derive(Clone, Copy)]
+pub struct Unsigned18Bit {
+    pub(crate) bits: u32,
+}
+
+/// `Unsigned36Bit` is the basic machine word of the TX-2.  This is
+/// the width of the registers in the Arithmetic Unit, and it is the
+/// unit on which the Exchange Unit operates when performing memory
+/// fetches or stores.  This is also the width of all instructions.
+#[derive(Clone, Copy)]
+pub struct Unsigned36Bit {
+    pub(crate) bits: u64,
+}
+
+unsigned_ones_complement_impl!(Unsigned5Bit, 5, u8, Signed5Bit);
+unsigned_ones_complement_impl!(Unsigned6Bit, 6, u8, Signed6Bit);
+unsigned_ones_complement_impl!(Unsigned9Bit, 9, u16, Signed9Bit);
+unsigned_ones_complement_impl!(Unsigned18Bit, 18, u32, Signed18Bit);
+unsigned_ones_complement_impl!(Unsigned36Bit, 36, u64, Signed36Bit);
+
+////////////////////////////////////////////////////////////////////////
+// Unsigned5Bit
+////////////////////////////////////////////////////////////////////////
+
+// all the things that always fit into Unsigned5Bit
+// (there are none)
+// all the things that Unsigned5Bit always fits into
+from_self_to_native_type!(Unsigned5Bit, u8 i8 u16 i16 u32 i32 u64 i64 usize);
+// all the things that Unsigned5Bit may not fit into
+// (there are none)
+// all the things that may not fit into Unsigned5Bit
+try_from_native_type_to_self!(Unsigned5Bit, u8, i8 u8 u16 i16 u32 i32 u64 i64 usize);
+
+////////////////////////////////////////////////////////////////////////
+// Unsigned6Bit
+////////////////////////////////////////////////////////////////////////
+
+// all the things that always fit into Unsigned6Bit
+// (there are none)
+// all the things that Unsigned5Bit always fits into
+from_self_to_native_type!(Unsigned6Bit, u8 i8 u16 i16 u32 i32 u64 i64 usize);
+// all the things that Unsigned6Bit may not fit into
+// (there are none)
+// all the things that may not fit into Unsigned6Bit
+try_from_native_type_to_self!(Unsigned6Bit, u8, i8 u8 u16 i16 u32 i32 u64 i64 usize);
+
+////////////////////////////////////////////////////////////////////////
+// Unsigned9Bit
+////////////////////////////////////////////////////////////////////////
+
+// all the things that always fit into Unsigned9Bit
+from_native_type_to_self!(Unsigned9Bit, u8);
+// all the things that Unsigned9Bit always fits into
+from_self_to_native_type!(Unsigned9Bit, u16 i16 u32 i32 u64 i64);
+// all the things that Unsigned9Bit may not fit into
+try_from_self_to_native_type!(Unsigned9Bit, u8 i8);
+// all the things that may not fit into Unsigned9Bit
+try_from_native_type_to_self!(Unsigned9Bit, u16, i8 u16 i16 u32 i32 u64 i64);
+
+impl From<Unsigned5Bit> for Unsigned9Bit {
+    fn from(n: Unsigned5Bit) -> Self {
+        Self {
+            bits: n.bits.into(),
+        }
+    }
+}
+
+////////////////////////////////////////////////////////////////////////
+// Unsigned18Bit
+////////////////////////////////////////////////////////////////////////
+
+// all the things that always fit into Unsigned18Bit
+from_native_type_to_self!(Unsigned18Bit, u8 u16);
+// all the things that Unsigned18Bit always fits into
+from_self_to_native_type!(Unsigned18Bit, u32 i32 u64 i64);
+// all the things Unsigned18Bit may not fit into
+try_from_self_to_native_type!(Unsigned18Bit, u8 i8 u16 i16);
+// all the things that may not fit into Unsigned18Bit
+try_from_native_type_to_self!(Unsigned18Bit, u32, i8 i16 u32 i32 u64 i64);
+
+impl From<Unsigned5Bit> for Unsigned18Bit {
+    fn from(n: Unsigned5Bit) -> Self {
+        Self {
+            bits: n.bits.into(),
+        }
+    }
+}
+
+impl From<Unsigned9Bit> for Unsigned18Bit {
+    fn from(n: Unsigned9Bit) -> Self {
+        Self {
+            bits: n.bits.into(),
+        }
+    }
+}
+
+////////////////////////////////////////////////////////////////////////
+// Unsigned36Bit
+////////////////////////////////////////////////////////////////////////
+
+// all the things that always fit into Unsigned36Bit
+from_native_type_to_self!(Unsigned36Bit, u8 u16 u32);
+// all the things that Unsigned36Bit always fits into
+from_self_to_native_type!(Unsigned36Bit, u64 i64);
+// all the things Unsigned36Bit may not fit into
+try_from_self_to_native_type!(Unsigned36Bit, u8 i8 u16 i16 u32 i32);
+// all the things that may not fit into Unsigned36Bit
+try_from_native_type_to_self!(Unsigned36Bit, u64, i8 i16 i32 u64 i64);
+
+impl TryFrom<Unsigned36Bit> for Unsigned6Bit {
+    type Error = ConversionFailed;
+    fn try_from(n: Unsigned36Bit) -> Result<Self, ConversionFailed> {
+	match u8::try_from(n.bits) {
+	    Ok(n) => {
+		if n > Self::VALUE_BITS {
+		    Err(ConversionFailed::TooLarge)
+		} else {
+		    Ok(Self {
+			bits: n,
+		    })
+		}
+	    }
+	    Err(_) => Err(ConversionFailed::TooLarge),
+	}
+    }
+}
+impl From<Unsigned5Bit> for Unsigned36Bit {
+    fn from(n: Unsigned5Bit) -> Self {
+        Self {
+            bits: n.bits.into(),
+        }
+    }
+}
+
+impl From<Unsigned9Bit> for Unsigned36Bit {
+    fn from(n: Unsigned9Bit) -> Self {
+        Self {
+            bits: n.bits.into(),
+        }
+    }
+}
+
+impl From<Unsigned18Bit> for Unsigned36Bit {
+    fn from(n: Unsigned18Bit) -> Self {
+        Self {
+            bits: n.bits.into(),
+        }
+    }
+}
+
+impl From<Unsigned6Bit> for Unsigned9Bit {
+    fn from(n: Unsigned6Bit) -> Self {
+	Self {
+	    bits: n.bits.into()
+	}
+    }
+}

--- a/base/src/onescomplement/unsigned/tests.rs
+++ b/base/src/onescomplement/unsigned/tests.rs
@@ -1,0 +1,435 @@
+use std::ops::Shl;
+use std::ops::Shr;
+
+use super::{ConversionFailed, Unsigned9Bit};
+
+macro_rules! assert_octal_eq {
+    ($left:expr, $right:expr $(,)?) => {{
+        match (&$left, &$right) {
+            (left_val, right_val) => {
+                if !(*left_val == *right_val) {
+                    panic!(
+                        "Assertion failed: {:>#012o} != {:>#012o}",
+                        left_val, right_val
+                    );
+                }
+            }
+        }
+    }};
+}
+
+#[test]
+fn test_unsigned9bit_max() {
+    assert_eq!(Unsigned9Bit::MAX.bits, 0o777);
+}
+
+#[test]
+fn test_unsigned9bit_min() {
+    assert_eq!(Unsigned9Bit::MIN.bits, 0);
+}
+
+#[test]
+fn test_from_u8() {
+    assert_eq!(Unsigned9Bit::from(0_u8).bits, 0_u16);
+    assert_eq!(Unsigned9Bit::from(1_u8).bits, 1_u16);
+    assert_eq!(Unsigned9Bit::from(0o377_u8).bits, 0o377_u16);
+}
+
+#[test]
+fn test_try_from_unsigned9bit_u8() {
+    assert_eq!(u8::try_from(Unsigned9Bit::from(0_u8)), Ok(0_u8));
+    assert_eq!(u8::try_from(Unsigned9Bit::from(1_u8)), Ok(1_u8));
+    assert_eq!(u8::try_from(Unsigned9Bit::from(0o377_u8)), Ok(0o377_u8));
+    assert_eq!(
+        u8::try_from(Unsigned9Bit {
+            bits: 0b011_111_111_u16
+        }),
+        Ok(0o377_u8)
+    );
+    // Setting the top bit doesn't make these values negative, unlike Signed9Bit.
+    assert_eq!(
+        u8::try_from(Unsigned9Bit {
+            bits: 0b111_111_110_u16
+        }),
+        Err(ConversionFailed::TooLarge)
+    );
+    assert_eq!(
+        u8::try_from(Unsigned9Bit {
+            bits: 0b110_000_000_u16
+        }),
+        Err(ConversionFailed::TooLarge)
+    );
+}
+
+#[test]
+fn test_i8_round_tripping() {
+    let mut prev: Option<Unsigned9Bit> = None;
+    for i in 0..i8::MAX {
+        let q: Unsigned9Bit = Unsigned9Bit::try_from(i).unwrap();
+        if let Some(qprev) = prev {
+            assert!(
+                q > qprev,
+                "failed to round-trip {}: {:?} should be greater than {:?}",
+                i,
+                q,
+                qprev
+            );
+        }
+        prev = Some(q);
+        match i8::try_from(q) {
+            Ok(out) => {
+                assert_eq!(i, out, "Round trip failed for {}->{:?}->{}", i, &q, out);
+            }
+            Err(e) => {
+                panic!(
+		    "Unexpected overflow when round-tripping  {}->{:?}-> [conversion to i8 failed with error {}]",
+		    i, &q, e);
+            }
+        }
+    }
+}
+
+#[test]
+fn test_u8_round_tripping() {
+    let mut prev: Option<Unsigned9Bit> = None;
+    for i in u8::MIN..u8::MAX {
+        let q: Unsigned9Bit = Unsigned9Bit::from(i);
+        if let Some(qprev) = prev {
+            assert!(
+                q > qprev,
+                "failed to round-trip {}: {:?} should be greater than {:?}",
+                i,
+                q,
+                qprev
+            );
+        }
+        prev = Some(q);
+        match u8::try_from(q) {
+            Ok(out) => {
+                assert_eq!(i, out, "Round trip failed for {}->{:?}->{}", i, &q, out);
+            }
+            Err(e) => {
+                panic!(
+		    "Unexpected overflow when round-tripping  {}->{:?}-> [conversion to i8 failed with error {}]",
+		    i, &q, e);
+            }
+        }
+    }
+}
+
+#[test]
+fn test_try_from_i8_unsigned9bit() {
+    assert_octal_eq!(Unsigned9Bit::try_from(0_i8).unwrap().bits, 0_u16);
+    assert_octal_eq!(Unsigned9Bit::try_from(1_i8).unwrap().bits, 1_u16);
+    assert_octal_eq!(Unsigned9Bit::try_from(127_i8).unwrap().bits, 127_u16);
+
+    assert_eq!(
+        Unsigned9Bit::try_from(-1_i8),
+        Err(ConversionFailed::TooSmall)
+    );
+    assert_eq!(
+        Unsigned9Bit::try_from(-2_i8),
+        Err(ConversionFailed::TooSmall)
+    );
+    assert_eq!(
+        Unsigned9Bit::try_from(-8_i8),
+        Err(ConversionFailed::TooSmall)
+    );
+    assert_eq!(
+        Unsigned9Bit::try_from(-128_i8),
+        Err(ConversionFailed::TooSmall)
+    );
+}
+
+#[test]
+fn test_unsigned9bit_zero_values() {
+    const ZERO: Unsigned9Bit = Unsigned9Bit { bits: 0_u16 };
+    assert_eq!(u16::from(ZERO), 0, "zero should convert to 0_u16");
+    assert_eq!(u8::try_from(ZERO), Ok(0), "zero should convert to 0_u8");
+
+    // The value that would be +0 in Signed9Bit is just a large value in Unsigned9Bit.
+    const CAREFUL_NOW: Unsigned9Bit = Unsigned9Bit {
+        bits: 0b111_111_111_u16,
+    };
+    assert_eq!(u16::try_from(CAREFUL_NOW), Ok(0o777));
+}
+
+#[test]
+fn test_from_unsigned9bit_to_i8() {
+    assert_eq!(i8::try_from(Unsigned9Bit { bits: 0 }), Ok(0_i8));
+    assert_eq!(i8::try_from(Unsigned9Bit { bits: 1 }), Ok(1_i8));
+    assert_eq!(i8::try_from(Unsigned9Bit { bits: 127_u16 }), Ok(127_i8));
+    assert_eq!(
+        i8::try_from(Unsigned9Bit {
+            bits: 0b111_111_110_u16
+        }),
+        Err(ConversionFailed::TooLarge)
+    );
+    assert_eq!(
+        i8::try_from(Unsigned9Bit {
+            bits: 0b111_111_101_u16
+        }),
+        Err(ConversionFailed::TooLarge)
+    );
+    assert_eq!(
+        i8::try_from(Unsigned9Bit {
+            bits: 0b110_111_101_u16
+        }),
+        Err(ConversionFailed::TooLarge)
+    );
+    assert_eq!(
+        i8::try_from(Unsigned9Bit {
+            bits: 0b110_000_000_u16
+        }),
+        Err(ConversionFailed::TooLarge)
+    );
+    assert!(i8::try_from(Unsigned9Bit::MAX).is_err());
+    assert_eq!(i8::try_from(Unsigned9Bit::MIN), Ok(0));
+}
+
+#[test]
+fn test_from_u16_to_unsigned9bit() {
+    assert_octal_eq!(Unsigned9Bit::try_from(0_u16).unwrap().bits, 0_u16);
+    assert_octal_eq!(Unsigned9Bit::try_from(1_u16).unwrap().bits, 1_u16);
+    assert_octal_eq!(Unsigned9Bit::try_from(0o377_u16).unwrap().bits, 0o377_u16);
+    assert_octal_eq!(Unsigned9Bit::try_from(0o400_u16).unwrap().bits, 0o400);
+    assert_eq!(
+        Unsigned9Bit::try_from(0o1000_u16),
+        Err(ConversionFailed::TooLarge)
+    );
+}
+
+#[test]
+fn test_from_unsigned9bit_to_u16() {
+    assert_octal_eq!(u16::from(Unsigned9Bit { bits: 0 }), 0);
+    assert_octal_eq!(u16::from(Unsigned9Bit { bits: 1 }), 1);
+    assert_octal_eq!(u16::from(Unsigned9Bit { bits: 0o377_u16 }), 0o377_u16);
+    assert_octal_eq!(u16::from(Unsigned9Bit { bits: 0o400_u16 }), 0o400_u16);
+    assert_octal_eq!(u16::from(Unsigned9Bit { bits: 0o477_u16 }), 0o477_u16);
+    assert_octal_eq!(u16::from(Unsigned9Bit { bits: 0o777_u16 }), 0o777_u16);
+}
+
+#[test]
+fn test_unsigned9bit_ord() {
+    let zero: Unsigned9Bit = Unsigned9Bit::from(0_u8);
+    let one: Unsigned9Bit = Unsigned9Bit::from(1_u8);
+    assert!(zero < one);
+    assert!(!(one < zero));
+    assert!(!(zero < zero));
+    assert!(!(one < one));
+
+    assert!(one > zero);
+    assert!(!(zero > zero));
+    assert!(!(one > one));
+    assert!(!(zero > one));
+
+    assert!(Unsigned9Bit::MIN < Unsigned9Bit::MAX);
+    assert!(Unsigned9Bit::MAX > Unsigned9Bit::MIN);
+}
+
+#[test]
+fn test_unsigned9bit_eq() {
+    let zero: Unsigned9Bit = Unsigned9Bit::from(0_u8);
+    let one: Unsigned9Bit = Unsigned9Bit::from(1_u8);
+    assert_eq!(zero, zero);
+    assert_eq!(one, one);
+
+    let another_one: Unsigned9Bit = Unsigned9Bit::from(1_u8);
+    assert_eq!(
+        one, another_one,
+        "ensure we don't confuse identy with equality"
+    );
+}
+
+#[test]
+fn test_unsigned9bit_checked_add() {
+    let zero: Unsigned9Bit = Unsigned9Bit::from(0_u8);
+    let one: Unsigned9Bit = Unsigned9Bit::from(1_u8);
+
+    // Test the basics: adding zero to something leaves it unchanged.
+    assert_eq!(zero.checked_add(zero), Some(zero));
+    assert_eq!(zero.checked_add(one), Some(one));
+    assert_eq!(one.checked_add(zero), Some(one));
+    assert_eq!(Unsigned9Bit::MAX.checked_add(zero), Some(Unsigned9Bit::MAX));
+    assert_eq!(Unsigned9Bit::MIN.checked_add(zero), Some(Unsigned9Bit::MIN));
+
+    // Test the basics: 1+1=2
+    let two: Unsigned9Bit = Unsigned9Bit::from(2_u8);
+    assert_eq!(one.checked_add(one), Some(two));
+
+    // Verify that we correctly detect overflow
+    assert_eq!(Unsigned9Bit::MAX.checked_add(one), None);
+}
+
+#[test]
+fn test_unsigned9bit_checked_sub() {
+    let zero: Unsigned9Bit = Unsigned9Bit::from(0_u8);
+    let one: Unsigned9Bit = Unsigned9Bit::from(1_u8);
+
+    // Test the basics: adding zero to something leaves it unchanged.
+    assert_eq!(zero.checked_sub(zero), Some(zero));
+    assert_eq!(one.checked_sub(zero), Some(one));
+    assert_eq!(Unsigned9Bit::MAX.checked_sub(zero), Some(Unsigned9Bit::MAX));
+    assert_eq!(Unsigned9Bit::MIN.checked_sub(zero), Some(Unsigned9Bit::MIN));
+
+    // Test the basics: 2-1=1
+    let two: Unsigned9Bit = Unsigned9Bit::from(2_u8);
+    assert_eq!(two.checked_sub(one), Some(one));
+    assert_eq!(two.checked_sub(two), Some(zero));
+
+    // Verify that we correctly detect overflow
+    assert_eq!(Unsigned9Bit::MIN.checked_sub(one), None);
+    assert_eq!(zero.checked_sub(one), None); // same thing
+
+    assert_eq!(
+        u16::from(Unsigned9Bit::MAX.checked_sub(one).unwrap()),
+        510_u16
+    );
+}
+
+#[test]
+fn test_unsigned9bit_abs() {
+    let zero: Unsigned9Bit = Unsigned9Bit::from(0_u8);
+    let one: Unsigned9Bit = Unsigned9Bit::from(1_u8);
+    assert_eq!(zero, zero.abs());
+    assert_eq!(one, one.abs());
+}
+
+#[test]
+fn test_unsigned9bit_checked_abs() {
+    let zero: Unsigned9Bit = Unsigned9Bit::from(0_u8);
+    let one: Unsigned9Bit = Unsigned9Bit::from(1_u8);
+    assert_eq!((zero, false), zero.overflowing_abs());
+    assert_eq!((one, false), one.overflowing_abs());
+}
+
+#[test]
+fn test_unsigned9bit_not() {
+    let all_zeroes = Unsigned9Bit { bits: 0 };
+    let all_ones = Unsigned9Bit { bits: 0o777 };
+    assert_eq!(!all_zeroes, all_ones);
+    assert_eq!(!all_ones, all_zeroes);
+
+    assert_eq!(!Unsigned9Bit { bits: 1 }, Unsigned9Bit { bits: 0o776 });
+    assert_eq!(!Unsigned9Bit { bits: 0o40 }, Unsigned9Bit { bits: 0o737 });
+}
+
+#[test]
+fn test_unsigned9bit_and() {
+    let all_zeroes = Unsigned9Bit { bits: 0 };
+    let all_ones = Unsigned9Bit { bits: 0o777 };
+    assert_eq!(all_zeroes & all_zeroes, all_zeroes);
+    assert_eq!(all_ones & all_ones, all_ones);
+    assert_eq!(all_ones & all_zeroes, all_zeroes);
+
+    let three = Unsigned9Bit { bits: 0o3 };
+    let two = Unsigned9Bit { bits: 0o2 };
+    assert_eq!(three & two, two);
+}
+
+#[test]
+fn test_unsigned9bit_impl_and() {
+    let all_zeroes = Unsigned9Bit { bits: 0 };
+    let all_ones = Unsigned9Bit { bits: 0o777 };
+    assert_eq!(all_zeroes.and(0_u16), all_zeroes);
+    assert_eq!(all_ones.and(0o777_u16), all_ones);
+    assert_eq!(all_ones.and(0_u16), all_zeroes);
+
+    let three = Unsigned9Bit { bits: 0o3 };
+    let two = Unsigned9Bit { bits: 0o2 };
+    assert_eq!(three & 0o2_u16, two);
+}
+
+#[test]
+fn test_unsigned9bit_or() {
+    let all_zeroes = Unsigned9Bit { bits: 0 };
+    let all_ones = Unsigned9Bit { bits: 0o777 };
+    assert_eq!(all_zeroes & all_zeroes, all_zeroes);
+    assert_eq!(all_ones | all_ones, all_ones);
+    assert_eq!(all_ones | all_zeroes, all_ones);
+
+    let three = Unsigned9Bit { bits: 0o3 };
+    let two = Unsigned9Bit { bits: 0o2 };
+    assert_eq!(three | two, three);
+    assert_eq!(three | all_zeroes, three);
+    assert_eq!(three | all_ones, all_ones);
+}
+
+#[test]
+fn test_unsigned9bit_shr() {
+    let zero: Unsigned9Bit = Unsigned9Bit::from(0_u8);
+    let one: Unsigned9Bit = Unsigned9Bit::from(1_u8);
+    assert_eq!(zero.shr(zero), zero);
+    assert_eq!(zero.shr(one), zero);
+    assert_eq!(one.shr(zero), one);
+
+    // Shifting the least significant bit off the right-hand side puts
+    // it into the most-signficant position.
+    assert_eq!(one.shr(one), Unsigned9Bit::ZERO | (1_u16 << 8));
+
+    // If we shift a bit more places to the right than there are bit
+    // positions, it just ends up in the position determined by the
+    // obvious modulus operation (and e.g. does not get zeroed).
+    //
+    // Shift right by   ... is equivalent to shifting right by
+    //              9                                        0
+    //             10                                        1
+    //             11                                        2
+    //             12                                        3
+    //             13                                        4
+    // ...
+    //             31                                        4
+    assert_eq!(one.shr(Unsigned9Bit::from(9_u8)), one);
+    assert_eq!(
+        one.shr(Unsigned9Bit::from(10_u8)),
+        Unsigned9Bit::try_from(0o400).unwrap()
+    );
+    assert_eq!(
+        one.shr(Unsigned9Bit::from(11_u8)),
+        Unsigned9Bit::try_from(0o200).unwrap()
+    );
+    assert_eq!(
+        one.shr(Unsigned9Bit::from(12_u8)),
+        Unsigned9Bit::try_from(0o100).unwrap()
+    );
+    assert_eq!(
+        one.shr(Unsigned9Bit::from(13_u8)),
+        Unsigned9Bit::try_from(0o040).unwrap()
+    );
+    assert_eq!(
+        one.shr(Unsigned9Bit::from(31_u8)),
+        Unsigned9Bit::try_from(0o040).unwrap()
+    );
+
+    let all_ones = Unsigned9Bit { bits: 0o777 };
+    assert_eq!(all_ones.shr(zero), all_ones);
+    assert_eq!(all_ones.shr(one), all_ones);
+    assert_eq!(all_ones.shr(all_ones), all_ones);
+}
+
+#[test]
+fn test_unsigned9bit_shl() {
+    let zero: Unsigned9Bit = Unsigned9Bit::from(0_u8);
+    let one: Unsigned9Bit = Unsigned9Bit::from(1_u8);
+    assert_eq!(zero.shl(zero), zero);
+    assert_eq!(zero.shl(one), zero);
+    assert_eq!(one.shl(zero), one);
+
+    let two: Unsigned9Bit = Unsigned9Bit::from(2_u8);
+    assert_eq!(one.shl(one), two);
+
+    assert_octal_eq!(
+        Unsigned9Bit::try_from(0o400).unwrap().shl(1),
+        Unsigned9Bit::from(1_u8)
+    );
+
+    assert_octal_eq!(
+        Unsigned9Bit::try_from(0o020).unwrap().shl(14),
+        Unsigned9Bit::from(1_u8)
+    );
+
+    assert_eq!(Unsigned9Bit::ZERO, Unsigned9Bit::ZERO << Unsigned9Bit::ZERO);
+    assert_eq!(Unsigned9Bit::ZERO, Unsigned9Bit::ZERO << Unsigned9Bit::ONE);
+    assert_eq!(Unsigned9Bit::ONE, Unsigned9Bit::ONE << Unsigned9Bit::ZERO);
+    assert_eq!(Unsigned9Bit::from(4_u8), Unsigned9Bit::ONE << Unsigned9Bit::from(2_u8));
+}

--- a/base/src/prelude.rs
+++ b/base/src/prelude.rs
@@ -1,0 +1,10 @@
+//! The prelude exports a number of structs which are useful in
+//! representing things to do with the TX-2.  Providing this prelude
+//! is the main purpose of the base crate.
+pub use crate::instruction::*;
+pub use crate::onescomplement::signed::*;
+pub use crate::onescomplement::unsigned::*;
+pub use crate::subword::join_halves;
+pub use crate::subword::join_quarters;
+pub use crate::types::IndexBy;
+pub use crate::types::*;

--- a/base/src/subword.rs
+++ b/base/src/subword.rs
@@ -1,0 +1,110 @@
+//! Various convenience utilities for splitting 36-bit TX-2 words
+//! into smaller components and for joining them together.
+use std::ops::Shl;
+
+use crate::onescomplement::unsigned::{Unsigned18Bit, Unsigned36Bit, Unsigned9Bit};
+
+/// Split a 36-bit word into two 18-bit values.
+pub fn split_halves(w: Unsigned36Bit) -> (Unsigned18Bit, Unsigned18Bit) {
+    (left_half(w), right_half(w))
+}
+
+/// Join two 18-bit values into a 36-bit word.
+pub fn join_halves(left: Unsigned18Bit, right: Unsigned18Bit) -> Unsigned36Bit {
+    Unsigned36Bit::from(left).shl(18) | Unsigned36Bit::from(right)
+}
+
+/// Join two quarters into a halfword.
+pub fn join_quarters(left: Unsigned9Bit, right: Unsigned9Bit) -> Unsigned18Bit {
+    Unsigned18Bit::from(left).shl(9) | Unsigned18Bit::from(right)
+}
+
+/// Extract the right (more-significant) halfword from a full word.
+pub fn right_half(word: Unsigned36Bit) -> Unsigned18Bit {
+    let bits: u64 = u64::from(word);
+    Unsigned18Bit::try_from(bits & 0o777_777).unwrap()
+}
+
+/// Extract the right (less-significant) halfword from a full word.
+pub fn left_half(word: Unsigned36Bit) -> Unsigned18Bit {
+    let bits: u64 = u64::from(word) >> 18;
+    Unsigned18Bit::try_from(bits & 0o777_777).unwrap()
+}
+
+/// Split a halfword into left (more significant) and right (less
+/// significant) 9-bit quarters (in the sense that they are quarters
+/// of the original 26-bit full word).
+pub fn split_halfword(halfword: Unsigned18Bit) -> (Unsigned9Bit, Unsigned9Bit) {
+    let bits: u32 = u32::from(halfword);
+    (Unsigned9Bit::try_from((bits >> 9) & 0o777).unwrap(),
+     Unsigned9Bit::try_from((bits     ) & 0o777).unwrap())
+}
+
+/// Split a 36-bit word into four 9-bit quarters.  The result is a
+/// tuple which contains the quarters ordered from most-significant
+/// (Q4) to least-significant (Q1).
+pub fn quarters(word: Unsigned36Bit) -> [Unsigned9Bit; 4] {
+    let (left, right) = split_halves(word);
+    let (q4, q3) = split_halfword(left);
+    let (q2, q1) = split_halfword(right);
+    [q4, q3, q2, q1]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::onescomplement::unsigned::{Unsigned18Bit, Unsigned36Bit, Unsigned9Bit};
+
+    macro_rules! assert_octal_eq {
+        ($left:expr, $right:expr $(,)?) => {{
+            match (&$left, &$right) {
+                (left_val, right_val) => {
+                    if !(*left_val == *right_val) {
+                        panic!(
+                            "Assertion failed: {:>#012o} != {:>#012o}",
+                            left_val, right_val
+                        );
+                    }
+                }
+            }
+        }};
+    }
+
+    #[test]
+    fn test_join_halves() {
+        assert_octal_eq!(
+            join_halves(
+                Unsigned18Bit::try_from(0o123_456_u32).unwrap(),
+                Unsigned18Bit::try_from(0o525_252_u32).unwrap()
+            ),
+            Unsigned36Bit::try_from(0o123_456_525_252_u64).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_join_quarters() {
+        assert_octal_eq!(
+            join_quarters(
+                Unsigned9Bit::try_from(0o123_u16).unwrap(),
+                Unsigned9Bit::try_from(0o456_u16).unwrap()
+            ),
+            Unsigned18Bit::try_from(0o123_456_u32).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_split_halfword() {
+        let h = Unsigned18Bit::try_from(0o123_456_u32).expect("valid test data");
+	assert_eq!(split_halfword(h), (Unsigned9Bit::try_from(0o123).unwrap(),
+				       Unsigned9Bit::try_from(0o456).unwrap()));
+    }
+
+    #[test]
+    fn test_quarters() {
+	fn q(n: u16) -> Unsigned9Bit {
+	    Unsigned9Bit::try_from(n).expect("valid test data")
+	}
+	assert_eq!(quarters(Unsigned36Bit::try_from(0o123_456_525_252_u64).unwrap()),
+		   [q(0o123), q(0o456), q(0o525), q(0o252)])
+    }
+}

--- a/base/src/types.rs
+++ b/base/src/types.rs
@@ -1,0 +1,307 @@
+/// The TX-2 uses 36-bit words.  We use Unsigned36Bit (defined in
+/// onescomplement/unsigned.rs) to represent this.  As stored in
+/// memory, there are two additional bits; these are implemented in
+/// the CPU emulation, not here.
+
+use std::cmp::Ordering;
+use std::fmt::{Debug, Display, Error, Formatter, Octal};
+
+use crate::onescomplement::error::ConversionFailed;
+use crate::onescomplement::signed::{
+    Signed5Bit,
+    Signed6Bit,
+    Signed18Bit,
+};
+use crate::onescomplement::unsigned::{
+    Unsigned18Bit,
+    Unsigned36Bit,
+    Unsigned6Bit,
+};
+use crate::onescomplement::{Sign, WordCommon};
+
+/// The `IndexBy` trait implements address arithmetic (adding a signed
+/// or unsigned value to an address).
+///
+/// On page 12-9, Volume 2 of the Technical Manual contains some
+/// wording that I interpret to mean that address indexation arithmetic
+/// wraps:
+///
+/// > While the sum of a base address in N₂,₁ and an index register in
+/// > X is being formed betweek PK¹³ and PK²², the X Adder carry
+/// > circuit is forced into a "set" condition.  This causes the sum
+/// > of an 18 bit number and its 18 bit ONE's complement to be all
+/// > ZEROS, rather than all ONES, if this sum should be formed.  The
+/// > comuted address of an operand, deferred address, or next
+/// > instruction then becomes the first register of the S Memory
+/// > (address 0) rather than the last register of the V mMemory
+/// > (address 377 777 (octal)), when, for example, the base address
+/// > is 000 004 and the index is 777 773.  The logic for obtaining
+/// > this result simply uses the PK¹³ᵝ 0.4 microsecond time level to
+/// > set the X Adder carry circuit at the time that XAC would
+/// > ordinarily have been used to clear it.
+///
+/// IndexBy is also used to increment the program counter, and on the
+/// real TX2 this was done by a special circuit, not an adder.
+/// Volume 2 of the Technical Manual (section 12-2.3 "P REGISTER
+/// DRIVER LOGIC") states,
+///
+/// > Information can be transferred into the P register only from the
+/// > X Adder.  In addition to this single transfer path, ther P
+/// > register has a counter which can index the contents of the P
+/// > register by one.  Note that count circuit does not alter the
+/// > contents of P₂.₉
+pub trait IndexBy<T> {
+    fn index_by(&self, delta: T) -> Address;
+}
+
+/// An address has 17 normal value bits.  There are 18 bits for the
+/// operand base address in the instruction word, but the topmost bit
+/// signals a deferred (i.e. indirect) access, so we should never see
+/// a memory access to an address with the 0o400_000 bit set.
+///
+/// The program counter can also have its top bit set.  This signals
+/// that in the TX-2 hardware, the associated sequence should be
+/// traced via Trap 42.
+///
+/// The Xj (index) registers form an 18-bit ring and are described on
+/// page 3-68 of the User Handbook (section 3-3.1) as being signed
+/// integers.  Yet P (which also holds an address) is described on the
+/// same page as being a positive integer.  Therefore when performing
+/// address arithmetic, we sometimes need to convert index register
+/// values to the [`Signed18Bit`] type.
+#[derive(Clone, Copy)]
+pub struct Address(Unsigned18Bit);
+
+/// Placeholders (saved sequence instruction pointers in the index
+/// registers) use bit 2.9 to indicate that sequence switches to
+/// marked sequences should trap to sequence 42.  This means that the
+/// mark bit needs to be retained in the program counter (P register)
+/// so that the sequence is still "marked" after it has run.
+pub const PLACEHOLDER_MARK_BIT: Unsigned18Bit = Unsigned18Bit::MAX.and(1u32 << 17); // bit 2.9
+
+impl Address {
+    pub const ZERO: Address = Address(Unsigned18Bit::ZERO);
+    pub const MAX: Address = Address(Unsigned18Bit::MAX);
+
+    /// Apply a bitmask to an address.  This could also be done via
+    /// [`std::ops::BitAnd`], but trait implementations cannot be
+    /// const.  Implementing this const methods allows us to form
+    /// address constants at compile time with code like `Address::MAX
+    /// & 0o03400`.
+    pub const fn and(&self, mask: u32) -> Address {
+        Address(self.0.and(mask)) // use same hack in Unsigned18Bit.
+    }
+
+    /// Extract the placeholder mark bit.
+    pub fn mark_bit(&self) -> Unsigned18Bit {
+        self.0 & PLACEHOLDER_MARK_BIT
+    }
+
+    /// The placeholder phrasing here comes from the "TRAP 42"
+    /// features.  But the high bit in the operand address field in an
+    /// instruction also marks the operand as using deferred
+    /// addressing.  We should choose more neutral naming to avoid
+    /// confusion.
+    pub fn is_marked_placeholder(&self) -> bool {
+        self.0 & PLACEHOLDER_MARK_BIT != 0_u16
+    }
+
+    /// Split an address into its bottom 17 bits (which corresponds to
+    /// an actual memory register on the TX-2) and a "mark" bit.  The
+    /// "mark" bit is variously used to signal deferred addressing
+    /// when fetching operands, and to flag a sequence for tracing
+    /// with trap 42 (in this context is is called a "placeholder mark
+    /// bit").  The `split` method is the opposite of `join`.
+    pub fn split(&self) -> (Unsigned18Bit, bool) {
+        let without_mark: Unsigned18Bit = self.0 & !PLACEHOLDER_MARK_BIT;
+        (without_mark, self.is_marked_placeholder())
+    }
+
+    /// Form an address from the bottom 17 bits of `addr` and a
+    /// possilbe mark bit, `mark`.  If `mark` is false, the resulting
+    /// address will have a zero-valued top bit, no matter what is in
+    /// `addr`.  This is the opposite of `split`.
+    pub fn join(addr: Unsigned18Bit, mark: bool) -> Address {
+	let markbit: Unsigned18Bit = if mark { PLACEHOLDER_MARK_BIT } else { Unsigned18Bit::ZERO };
+	let addr_without_mark: Unsigned18Bit = addr & !PLACEHOLDER_MARK_BIT;
+	Address::from(markbit | addr_without_mark)
+    }
+
+    /// Computes the address following the current address.  Used,
+    /// among other things, to increment the program counter.
+    ///
+    /// The simulator relies on the fact that (as in the hardware TX-2
+    /// P register) this calculation will wrap from 0o377_777 to 0.
+    pub fn successor(&self) -> Address {
+        self.index_by(1_u8)
+    }
+}
+
+impl From<Unsigned18Bit> for Address {
+    fn from(a: Unsigned18Bit) -> Address {
+        Address(a)
+    }
+}
+
+impl From<Address> for Unsigned18Bit {
+    fn from(addr: Address) -> Self {
+        addr.0
+    }
+}
+
+impl From<Address> for Unsigned36Bit {
+    fn from(addr: Address) -> Self {
+        Unsigned36Bit::from(u32::from(addr))
+    }
+}
+
+impl IndexBy<u8> for Address {
+    fn index_by(&self, index: u8) -> Address {
+        let offset: Unsigned18Bit = index.into();
+        let (address, mark) = self.split();
+	Address::join(address.wrapping_add(offset) & !PLACEHOLDER_MARK_BIT, mark)
+    }
+}
+
+fn idx_impl(base: Address, delta: Signed18Bit) -> Result<Address, ConversionFailed> {
+    let (current, mark) = base.split();
+    let abs_delta: Unsigned18Bit = Unsigned18Bit::try_from(i32::from(delta.abs()))?;
+    let physical = match delta.signum() {
+        Sign::Zero => current,
+        Sign::Positive => current.wrapping_add(abs_delta),
+        Sign::Negative => current.wrapping_sub(abs_delta),
+    } & !PLACEHOLDER_MARK_BIT;
+    Ok(Address::join(physical, mark))
+}
+
+impl IndexBy<Signed5Bit> for Address {
+    fn index_by(&self, delta: Signed5Bit) -> Address {
+	idx_impl(*self, Signed18Bit::from(delta)).unwrap()
+    }
+}
+
+impl IndexBy<Signed6Bit> for Address {
+    fn index_by(&self, delta: Signed6Bit) -> Address {
+	idx_impl(*self, Signed18Bit::from(delta)).unwrap()
+    }
+}
+
+impl IndexBy<Signed18Bit> for Address {
+    fn index_by(&self, delta: Signed18Bit) -> Address {
+	idx_impl(*self, delta).unwrap()
+    }
+}
+
+#[test]
+fn index_by_5bit_quantity() {
+    let start: Address = Address::from(Unsigned18Bit::from(0o4000_u16));
+    let up: Signed5Bit = Signed5Bit::try_from(6_i8).unwrap();
+    assert_eq!(
+        start.index_by(up),
+        Address::from(Unsigned18Bit::from(0o4006_u16))
+    );
+
+    let down: Signed5Bit = Signed5Bit::try_from(-4_i8).unwrap();
+    assert_eq!(
+        start.index_by(down),
+        Address::from(Unsigned18Bit::from(0o3774_u16))
+    );
+}
+
+impl TryFrom<u32> for Address {
+    type Error = ConversionFailed;
+    fn try_from(n: u32) -> Result<Address, ConversionFailed> {
+        let value = Unsigned18Bit::try_from(n)?;
+        Ok(Address::from(value))
+    }
+}
+
+impl From<Address> for u32 {
+    fn from(a: Address) -> u32 {
+        u32::from(Unsigned18Bit::from(a))
+    }
+}
+
+impl From<&Address> for u32 {
+    fn from(a: &Address) -> u32 {
+        u32::from(Unsigned18Bit::from(*a))
+    }
+}
+
+impl Default for Address {
+    fn default() -> Address {
+        Address::from(Unsigned18Bit::from(0_u8))
+    }
+}
+
+impl Display for Address {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
+        // Always display as octal.
+        write!(f, "{:>08o}", self.0)
+    }
+}
+
+impl Octal for Address {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
+        let val = self.0;
+        Octal::fmt(&val, f) // delegate to u32's implementation
+    }
+}
+
+impl Debug for Address {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
+        // Always display as octal.
+        write!(f, "{:>08o}", self.0)
+    }
+}
+
+impl Ord for Address {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.0.cmp(&other.0)
+    }
+}
+
+impl PartialOrd for Address {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl PartialEq for Address {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.eq(&other.0)
+    }
+}
+
+impl PartialEq<u32> for Address {
+    fn eq(&self, other: &u32) -> bool {
+        let v: u32 = self.0.into();
+        v.eq(other)
+    }
+}
+impl Eq for Address {}
+
+pub type SequenceNumber = Unsigned6Bit;
+
+#[test]
+fn test_sequence_numnber() {
+    const ZERO: SequenceNumber = SequenceNumber::ZERO;
+    const ONE: SequenceNumber = SequenceNumber::ONE;
+
+    // Verify that left-shift works (becauise we will need it when
+    // handling flag raise/lower operations).
+    assert_eq!(SequenceNumber::try_from(2_u8).unwrap(), ONE << ONE);
+
+    // Verify that comparisons work (because we will need those when
+    // figuring out whether a raised flag should cause a sequence
+    // change).
+    assert!(ONE > ZERO);
+    assert!(ZERO < ONE);
+    assert_eq!(ONE, ONE);
+    assert_eq!(ZERO, ZERO);
+    assert!(!(ONE == ZERO));
+    assert!(!(ZERO == ONE));
+
+    // When SequenceNumber is Unsigned6Bit, SequenceNumber::MAX should be 0o77.
+    // assert_eq!(SequenceNumber::MAX, SequenceNumber::try_from(0o77_u8).unwrap());
+}

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "cli"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+cpu = {path = "../cpu" }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,0 +1,29 @@
+use cpu::{Alarm, ControlUnit, MemoryConfiguration, MemoryUnit, ResetMode};
+
+fn run_until_alarm(control: &mut ControlUnit, mem: &mut MemoryUnit) -> Result<(), Alarm> {
+    loop {
+        if !control.fetch_instruction(mem)? {
+            break;
+        }
+        control.execute_instruction(mem)?;
+    }
+    println!("machine is in limbo, terminating since there are no I/O devices yet");
+    Ok(())
+}
+
+fn run(control: &mut ControlUnit, mem: &mut MemoryUnit) {
+    control.codabo(&ResetMode::ResetTSP);
+    if let Err(e) = run_until_alarm(control, mem) {
+        eprintln!("Execution stopped: {}", e);
+    }
+}
+
+fn main() {
+    let mem_config = MemoryConfiguration {
+        with_u_memory: false,
+    };
+    let mut control = ControlUnit::new();
+    dbg!(&control);
+    let mut mem = MemoryUnit::new(&mem_config);
+    run(&mut control, &mut mem);
+}

--- a/cpu/Cargo.toml
+++ b/cpu/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "cpu"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+base = { path = "../base" }
+
+[lib]
+name = "cpu"
+path = "src/lib.rs"

--- a/cpu/src/alarm.rs
+++ b/cpu/src/alarm.rs
@@ -1,0 +1,72 @@
+use std::error::Error;
+use std::fmt::{self, Display, Formatter};
+
+use base::instruction::Instruction;
+use base::prelude::*;
+
+// Alarms from User's Handbook section 5-2.2
+#[derive(Debug)]
+pub enum Alarm {
+    PSAL(u32, String),                        // Program counter set to illegal address
+    OCSAL(Instruction, String),               // Illegal instruction was read into N register
+    QSAL(Instruction, Unsigned36Bit, String), // Q register (i.e. data fetch address) is set to illegal address
+    ROUNDTUITAL(String),                      // Something is not implemented
+}
+
+impl Display for Alarm {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+        use Alarm::*;
+        f.write_str("ALARM: ")?;
+        match self {
+            QSAL(instruction, address, msg) => {
+                write!(
+		    f,
+		    "QSAL: during execution of instruction {:?}, memory access to {:>013o} failed: {}",
+		    instruction,
+		    address,
+		    msg,
+		)
+            }
+            PSAL(address, msg) => {
+                write!(
+                    f,
+                    "PSAL: P register set to illegal address {:>013o}: {}",
+                    address, msg
+                )
+            }
+            OCSAL(inst, msg) => {
+                write!(
+                    f,
+                    "OCSAL: N register set to invalid instruction {:?}: {}",
+                    inst, msg
+                )
+            }
+            ROUNDTUITAL(msg) => {
+                write!(
+                    f,
+                    "ROUNDTUITAL: the program used a feature not supported in the emulator: {}",
+                    msg
+                )
+            }
+        }
+    }
+}
+
+impl Error for Alarm {}
+
+// Alarm conditions we expect to use in the emulator but
+// which are not in use yet:
+// IOSAL,			// I/O Alarm in IOS instruction; device broken/maintenance/nonexistent.
+// MISAL,			// Program too slow for I/O device.
+// SYAL1,                       // Sync alarm 1 (see User Handbook page 5-21)
+// SYAL2,                       // Sync alarm 2 (see User Handbook page 5-21)
+
+// Alarm enumerators we don't expect to use:
+//
+// MPAL,		     // data parity error (in STUV)
+// NPAL,		     // instruction parity error (in STUV)
+// XPAL,		     // parity error in X-memory
+// FPAL,		     // parity error in F-memory
+// TSAL,		     // voltage issue; can't happen in an emulator.
+// USAL,                     // voltage issue; can't happen in an emulator.
+// Mouse-trap

--- a/cpu/src/control.rs
+++ b/cpu/src/control.rs
@@ -1,0 +1,1047 @@
+//! Emulates the control unit of the TX-2.
+//!
+//! The control unit is conceptually similar to the CPU of a modern
+//! computer, except that the arithmetic unit and registers are
+//! separate.  Within this emulator, the control unit performs the
+//! following functions:
+//!
+//! - Instruction decoding
+//! - Handle CODABO and STARTOVER
+//! - Keep track of the flags of each sequence
+//! - Keep track of the placeholder of each sequence
+//! - Manage switching between sequences
+//! - Remember the setting of the TSP (Toggle Start Point) register
+
+use base::instruction::{Inst, Instruction, Opcode, OperandAddress, SymbolicInstruction};
+use base::prelude::*;
+use base::subword;
+
+use crate::alarm::Alarm;
+use crate::exchanger::{
+    exchanged_value,
+    SystemConfiguration,
+};
+use crate::memory::MemoryUnit;
+use crate::memorymap::{
+    BitChange,
+    ExtraBits,
+    MemoryMapped,
+    MemoryOpFailure,
+    MetaBitChange,
+    WordChange,
+    self,
+};
+
+#[derive(Debug)]
+enum ProgramCounterChange {
+    SequenceChange(Unsigned6Bit),
+    CounterUpdate,
+    Jump(Address),
+}
+
+/// Flags represent requests to run for instruction sequences (today
+/// one might describe these as threads).  Some sequences are special:
+///
+/// 0: Sequence which is run to start the computer (e.g. when "CODABO"
+/// or "START OVER" is pressed).
+///
+/// 41: Handles various I/O alarm conditions.
+/// 42: Handles various trap conditions (see Users Handbook page 42).
+/// 47: Handles miscellaneous inputs
+/// 50: DATRAC (A/D converter)
+/// 51: Xerox printer
+/// 52: PETR (paper tape reader)
+/// 54: Interval timer
+/// 55: Light pen
+/// 60: Oscilloscope display
+/// 61: RNG
+/// 63: Punch
+/// 65: Lincoln Writer input
+//  66: Lincoln Writer output
+/// 71: Lincoln Writer input
+/// 72: Lincoln Writer output
+/// 75: Misc output
+/// 76: Not for physical devices.
+/// 77: Not for physical devices.
+///
+/// The flag for sequences 76 and 77 may only be raised/lowered by
+/// program control.
+///
+/// The standard readin program executes the program it read in from
+/// the address specified by the program.  The program executes as
+/// sequence 52 (PETR) with the PETR unit initially turned off.
+///
+#[derive(Debug)]
+struct SequenceFlags {
+    flag_values: u64,
+}
+
+impl SequenceFlags {
+    fn new() -> SequenceFlags {
+        // New instances start with no flags raised (i.e. in "Limbo",
+        // STARTOVER not running).
+        SequenceFlags {
+	    flag_values: 0,
+	}
+    }
+
+    fn lower_all(&mut self) {
+        self.flag_values = 0;
+    }
+
+    fn flagbit(flag: &SequenceNumber) -> u64 {
+	1_u64 << u64::from(*flag)
+    }
+
+    fn lower(&mut self, flag: &SequenceNumber) {
+        assert!(u16::from(*flag) < 0o100_u16);
+        self.flag_values = self.flag_values & !SequenceFlags::flagbit(flag);
+    }
+
+    fn raise(&mut self, flag: &SequenceNumber) {
+        assert!(u16::from(*flag) < 0o100_u16);
+        self.flag_values = self.flag_values | SequenceFlags::flagbit(flag);
+    }
+
+    /// Return the index of the highest-priority (lowest-numbered)
+    /// flag.  If no flag is raised (the machine is in "Limbo"),
+    /// return None.
+    fn highest_priority_raised_flag(&self) -> Option<SequenceNumber> {
+        let n = self.flag_values.trailing_zeros();
+        if n == 64 {
+            None
+        } else {
+            Some(n.try_into().unwrap())
+        }
+    }
+}
+
+#[test]
+fn test_sequence_flags() {
+    let mut flags = SequenceFlags::new();
+
+    flags.lower_all();
+    assert_eq!(flags.highest_priority_raised_flag(), None);
+
+    flags.raise(&Unsigned6Bit::ZERO);
+    assert_eq!(flags.highest_priority_raised_flag().map(i8::from), Some(0_i8));
+    flags.raise(&Unsigned6Bit::ONE);
+    // 0 is still raised, so it still has the highest priority.
+    assert_eq!(flags.highest_priority_raised_flag(), Some(Unsigned6Bit::ZERO));
+
+    flags.lower(&SequenceNumber::ZERO);
+    assert_eq!(flags.highest_priority_raised_flag(), Some(Unsigned6Bit::ONE));
+    flags.lower(&SequenceNumber::ONE);
+    assert_eq!(flags.highest_priority_raised_flag(), None);
+
+    let four = SequenceNumber::try_from(4_i8).expect("valid test data");
+    let six = SequenceNumber::try_from(6_i8).expect("valid test data");
+    flags.raise(&four);
+    flags.raise(&six);
+    assert_eq!(flags.highest_priority_raised_flag(), Some(four));
+    flags.lower(&four);
+    assert_eq!(flags.highest_priority_raised_flag(), Some(six));
+}
+
+#[derive(Debug)]
+struct ControlRegisters {
+    pub e: Unsigned36Bit,
+    pub n: Instruction,
+    pub n_sym: Option<SymbolicInstruction>,
+    pub p: Address,
+    pub q: Address,
+
+    // The k register (User guide 4-3.1) holds the current sequence
+    // number (User guide 5-24).  k is Option<SequenceNumber> in order
+    // to allow the (emulated) control unit to recognise a CODABO
+    // button as indicating a need to change sequence from the control
+    // unit's initial state to sequence 0.
+    //
+    // This likely doesn't reflect the actual operation of the TX-2
+    // very well, and better understanding of the real operation of
+    // the machine will likely change this.
+    //
+    // I think that perhaps section 12-2.6.2 of Volume 2 of the
+    // technical manual may explain how the real TX-2 avoided this
+    // problem, but I don't think I understand what that section says.
+    // The text is:
+    //
+    // """12-2.6.2 XPS FLIP-FLOP LOGIC.  This flip-floop inhibits the
+    // X Memory strobe pulse into X when the register selected has the
+    // same address or the current program counter, is not register 0,
+    // and this is the first reference to this register since the last
+    // sequence change.  In this case all the cores of the register
+    // are clearered and only "junk" (with a 50-50 chance of a bad
+    // parity) would be strobed into X.  If XPS¹, then a clear pulse
+    // is substituted for the strobe pulse.
+    //
+    // The flip-flop is set whenever a sequence change occurs, and is
+    // cleared the first time thereafter that the program counter
+    // register is referenced during a PK cycle (if ever).  See Fig
+    // 12-8."""
+    pub k: Option<SequenceNumber>,
+
+    spr: Address, // Start Point Register
+
+    /// Index register 0 is the Toggle Start point.
+    /// Index registers 40-77 are program counters for the sequences.
+    ///
+    /// The index registers form an 18-bit ring (as stated in the
+    /// description of the AUX instruction) and are described on page
+    /// 3-68 of the User Handbook (section 3-3.1) as being signed
+    /// integers.
+    index_regs: [Signed18Bit; 0o100],	 // AKA the X memory
+    f_memory: [SystemConfiguration; 32], // the F memory
+    flags: SequenceFlags,
+    current_sequence_is_runnable: bool,
+}
+
+impl ControlRegisters {
+    fn new() -> ControlRegisters {
+        let fmem = {
+            let default_val = SystemConfiguration::try_from(0).unwrap();
+            [default_val; 32]
+        };
+        let mut result = ControlRegisters {
+            e: Unsigned36Bit::ZERO,
+            n: Instruction::invalid(), // not a valid instruction
+            n_sym: None,
+            p: Address::default(),
+            q: Address::default(),
+            k: None, // not 0, so that we can recognise CODABO.
+            index_regs: [Signed18Bit::default(); 0o100],
+            f_memory: fmem,
+            flags: SequenceFlags::new(),
+	    current_sequence_is_runnable: false,
+            spr: Address::default(),
+        };
+        // Index register 0 always contains 0.  This should still be
+        // true if we modify the behaviour of Address::default(),
+        // which is why we override it here.
+        result.index_regs[0] = Signed18Bit::ZERO;
+        result
+    }
+
+    fn previous_instruction_hold(&self) -> bool {
+        self.n.is_held()
+    }
+
+    fn set_spr(&mut self, addr: &Address) {
+        self.spr = *addr;
+    }
+
+    fn get_index_register(&self, n: Unsigned6Bit) -> Signed18Bit {
+	let n = usize::from(n);
+        assert_eq!(self.index_regs[0], 0);
+        assert!(n < 0o100);
+        return self.index_regs[usize::from(n)];
+    }
+
+    fn get_index_register_as_address(&mut self, n: Unsigned6Bit) -> Address {
+	let value: Signed18Bit = self.get_index_register(n);
+	Address::from(value.reinterpret_as_unsigned())
+    }
+
+    fn set_index_register(&mut self, n: Unsigned6Bit, value: &Signed18Bit) {
+	let n = usize::from(n);
+        assert_eq!(self.index_regs[0], 0);
+        assert_ne!(n, 0, "Index register 0 should be fixed at 0");
+        assert!(n < 0o100);
+        self.index_regs[n] = *value;
+    }
+
+    fn set_index_register_from_address(&mut self, n: Unsigned6Bit, addr: &Address) {
+	let value: Unsigned18Bit = Unsigned18Bit::from(*addr);
+	self.set_index_register(n, &value.reinterpret_as_signed());
+    }
+
+    fn get_f_mem(&self, n: Unsigned5Bit) -> SystemConfiguration {
+        assert!(u8::from(n) < 0o37_u8);
+        assert_eq!(self.f_memory[0], SystemConfiguration::zero());
+        let pos: usize = n.into();
+        self.f_memory[pos]
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum ResetMode {
+    ResetTSP = 0,
+    Reset0 = 0o03777710,
+    Reset1 = 0o03777711,
+    Reset2 = 0o03777712,
+    Reset3 = 0o03777713,
+    Reset4 = 0o03777714,
+    Reset5 = 0o03777715,
+    Reset6 = 0o03777716,
+    Reset7 = 0o03777717,
+}
+
+impl ResetMode {
+    fn address(&self) -> Option<Address> {
+        use ResetMode::*;
+        match self {
+            Reset0 | Reset1 | Reset2 | Reset3 | Reset4 | Reset5 | Reset6 | Reset7 => Some(
+                Address::from(Unsigned18Bit::try_from(*self as u32).unwrap()),
+            ),
+            ResetTSP => None, // need to read the TSP toggle switch.
+        }
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+enum SetMetabit {
+    Never,
+    //ForcedNever,		// by console switch
+    Instructions,
+    DeferredAddresses,
+    Operands,
+}
+
+#[derive(Debug)]
+pub struct ControlUnit {
+    regs: ControlRegisters,
+    running: bool,
+    /// `trap_on_change_sequence` is described in Users Handbook
+    /// section 4-5 No. 42, Trapping.
+    trap_on_change_sequence: bool,
+    set_metabit_mode: SetMetabit,
+}
+
+fn sign_extend_index_value(index_val: &Signed18Bit) -> Unsigned36Bit {
+    let left = if index_val.is_negative() {
+	Unsigned18Bit::MAX
+    } else {
+	Unsigned18Bit::ZERO
+    };
+    subword::join_halves(left, index_val.reinterpret_as_unsigned())
+}
+
+impl ControlUnit {
+    pub fn new() -> ControlUnit {
+        ControlUnit {
+            regs: ControlRegisters::new(),
+            running: false,
+            trap_on_change_sequence: false,
+            set_metabit_mode: SetMetabit::Never,
+        }
+    }
+
+    /// There are actually 9 different CODABO buttons (see page 5-18
+    /// of the User Guide).  and 9 different RESET buttons.
+    /// Each RESET button has a corresponding CODABO button.
+    /// See the `reset` method for address assignments.
+    ///
+    /// The CODABO operation leaves the Start Point Register set to
+    /// the selected start point.  There are also 9 reset buttons
+    /// which perform a similar task.
+    pub fn codabo(&mut self, reset_mode: &ResetMode) {
+        // TODO: clear alarms.
+        // We probably don't need an equivalent of resetting the
+        // control flip-flops in an emulator.  But if we did, that
+        // would happen here.
+        //
+        // On the other hand, the P register is described as an
+        // "18-bit flip-flop" in section 4-2.2 of the User Handbook,
+        // so perhaps all the registers in V memory are cleared by
+        // CODABO.
+        //
+        // TODO: clear the "connected" ("C") flip-flops in the I/O
+        // system.
+        println!("Starting CODABO {:?}", &reset_mode);
+        self.reset(reset_mode);
+        self.regs.flags.lower_all();
+	self.regs.current_sequence_is_runnable = false;
+        self.startover();
+        // TODO: begin issuing clock cycles.
+        println!("After CODABO, control unit contains {:#?}", &self);
+    }
+
+    /// There are 9 separate RESET buttons, for 8 fixed addresses and
+    /// another which uses the Toggle Start Point register.  There
+    /// appear to be two Toggle Start Point switches, one on the front
+    /// panel and a second on a remote control unit.  The
+    /// fixed-address RESET buttons correspond to the fixed
+    /// addresses 3777710 through 3777717, inclusive.
+    ///
+    /// RESET *only* loads the Start Point Register, nothing else.
+    pub fn reset(&mut self, reset_mode: &ResetMode) {
+        self.regs.set_spr(&match reset_mode.address() {
+            Some(address) => address,
+            None => self.tsp(),
+        });
+    }
+
+    /// Handle press of STARTOVER (or part of the operation of
+    /// CODABO).
+    pub fn startover(&mut self) {
+        self.regs.flags.raise(&SequenceNumber::ZERO);
+    }
+
+    /// Return the value in the Toggle Start Register.  It is likely
+    /// that this was memory-mapped in the real machine, but if that's
+    /// the case the user guide doesn't specify where.  For now, we
+    /// haven't made it configurable (i.e. have not emulated the
+    /// hardware) yet, either.  We just hard-code it to point at the
+    /// "Memory Clear / Memory Smear" program in the plugboard.
+    fn tsp(&self) -> Address {
+        // The operation of RESET (or CODABO) will copy this value
+        // into the zeroth index register (which the program counter
+        // placeholder for sequence 0).
+        memorymap::STANDARD_PROGRAM_CLEAR_MEMORY
+    }
+
+    fn change_sequence(&mut self, prev_seq: Option<SequenceNumber>, mut next_seq: SequenceNumber) {
+        // If the "Trap on Change Sequence" is enabled and the new
+        // sequence is marked (bit 2.9 of its index register is set).
+        // Activate unit 42, unless that's the unit which is giving up
+        // control.
+        //
+        // I'm not sure what should happen for the alternative case,
+        // where a unit of higher priority than 42 is marked for
+        // trap-on-sequence-change.
+        if prev_seq == Some(next_seq) {
+            // TODO: log a warning event.
+            return;
+        }
+
+	fn is_marked_placeholder(index_val: &Signed18Bit) -> bool {
+	    index_val < &0
+	}
+
+	let trap_seq = Unsigned6Bit::try_from(42).unwrap();
+        let sequence_change_trap = self.trap_on_change_sequence
+            && is_marked_placeholder(&self.regs.get_index_register(next_seq))
+            && self.regs.k != Some(trap_seq)
+            && next_seq > trap_seq;
+
+        let previous_sequence: Unsigned6Bit = match prev_seq {
+            None => Unsigned6Bit::ZERO,
+            Some(n) => n,
+        };
+        self.regs.e = join_halves(
+            join_quarters(Unsigned9Bit::from(previous_sequence),
+			  Unsigned9Bit::from(next_seq)),
+            Unsigned18Bit::from(self.regs.p),
+        );
+
+        if sequence_change_trap {
+            self.regs.flags.raise(&trap_seq);
+            next_seq = trap_seq;
+        }
+        self.regs.k = Some(next_seq);
+	if let Some(prev) = prev_seq {
+            let p = self.regs.p;
+            self.regs.set_index_register_from_address(prev, &p);
+        }
+	self.set_program_counter(ProgramCounterChange::SequenceChange(next_seq));
+    }
+
+    fn set_program_counter(&mut self, change: ProgramCounterChange) {
+	match change {
+	    ProgramCounterChange::SequenceChange(next_seq) => {
+		// According to the Technical Manual, page 12-6,
+		// change of seqeuence is the only time in which P₂.₉
+		// is altered.
+		if next_seq != 0 {
+		    self.regs.p = self.regs.get_index_register_as_address(next_seq);
+		} else {
+		    // Index register 0 is always 0, but by setting
+		    // the Toggle Status Register, the user can run
+		    // sequence 0 from an arbitrary address. That
+		    // address can't be stored in index register 0
+		    // since that's always 0, so we use an internal
+		    // "spr" register which is updated by the
+		    // RESET/CODABO buttons.  Here, we copy that saved
+		    // value into P.
+		    self.regs.p = self.regs.spr;
+		}
+	    }
+	    ProgramCounterChange::CounterUpdate => {
+		// Volume 2 of the Technical Manual (section 12-2.3 "P
+		// REGISTER DRIVER LOGIC") states, """Information can
+		// be transferred into the P register only from the X
+		// Adder.  In addition to this single transfer path,
+		// ther P register has a counter which can index the
+		// contents of the P register by one.  Note that count
+		// circuit does not alter the contents of P₂.₉"""
+		//
+		// Since P₂.₉ is the sign bit, this means that the P
+		// register wraps rather than overflows.
+		//
+		// As a practical matter, this wrap-around case means
+		// that self.regs.p previously contained 377,777.
+		// That is the last instruction in V Memory.  This is
+		// normally an unconditional JMP.  So in the standard
+		// plugboard configuration, we're going to take the
+		// jmp, meaning that we're never going to fetch an
+		// instruction from the address we just computed.
+		// But, this case may be needed to cover non-standard
+		// plugboard configurations.  According to the
+		// Technical Manual, page 12-6, change of seqeuence is
+		// the only time in which P₂.₉ is altered.
+		let (_old_physical, old_mark) = self.regs.p.split();
+		let new_p = self.regs.p.successor(); // p now points at the next instruction.
+		let (_new_physical, new_mark) = new_p.split();
+		assert_eq!(old_mark, new_mark);
+		self.regs.p = new_p;
+	    }
+	    ProgramCounterChange::Jump(new_p) => {
+		// Copy the value of P₂.₉ into `old_mark`.
+		let (_old_physical, old_mark) = self.regs.p.split();
+		// Update P, keeping the old value of P₂.₉.
+		self.regs.p = Address::join(new_p.into(), old_mark);
+	    }
+	}
+    }
+
+    pub fn fetch_instruction(&mut self, mem: &mut MemoryUnit) -> Result<bool, Alarm> {
+	// If the previous instruction was held, we don't even scan
+	// the flags.  This follows the description of how control
+	// handles flags in section 4-3.5 of the User Handbook (page
+	// 4-8).
+	if !self.regs.previous_instruction_hold() {
+            // Handle any possible change of sequence.
+            match self.regs.flags.highest_priority_raised_flag() {
+		None => {
+                    // The current sequence's flag is no longer raised.
+		    //
+		    // This happens either because the sequence was
+		    // dismissed (permanent or temporary drop-out) or IOSj
+		    // 40000 ("LOWER FLAG J") had been issued.  In the
+		    // latter case, the current sequence should continue
+		    // to run until another sequence's flag is raised.
+		    if !self.regs.current_sequence_is_runnable {
+			return Ok(false);
+		    }
+		}
+		Some(seq) => {
+                    println!("Highest-priority sequence is {}", seq);
+                    if Some(seq) == self.regs.k {
+			// just carry on.
+                    } else {
+			// Change of sequence.  Either seq is a higher
+			// priority than the current sequence, or the
+			// (previously) current sequence dropped out.
+			self.change_sequence(self.regs.k, seq);
+                    }
+		}
+            }
+	}
+
+        // self.regs.k now identifies the sequence we should be
+        // running and self.regs.p contains its program counter.
+
+        // Calculate the address from which we will fetch the
+        // instruction, and the increment the program counter.
+        let p_physical_address = Address::from(self.regs.p.split().0);
+	self.set_program_counter(ProgramCounterChange::CounterUpdate);
+
+	// Actually fetch the instruction.
+	let meta_op = match self.set_metabit_mode {
+            SetMetabit::Instructions => MetaBitChange::Set,
+            _ => MetaBitChange::None,
+        };
+        let instruction_word = match mem.fetch(&p_physical_address, &meta_op) {
+            Ok((inst, _meta)) => inst,
+            Err(e) => match e {
+                MemoryOpFailure::NotMapped => {
+                    return Err(Alarm::PSAL(
+                        u32::from(p_physical_address),
+                        "memory unit indicated physical address is not mapped".to_string(),
+                    ));
+                }
+                MemoryOpFailure::ReadOnly => unreachable!(),
+            },
+        };
+        println!(
+            "Fetched instruction {:?} from physical address {:?}",
+            instruction_word, p_physical_address
+        );
+	self.update_n_register(instruction_word)?;
+	Ok(true)		// not in Limbo (i.e. a sequence should run)
+    }
+
+    fn update_n_register(&mut self, instruction_word: Unsigned36Bit) -> Result<(), Alarm> {
+        self.regs.n = Instruction::from(instruction_word);
+        if let Ok(symbolic) = SymbolicInstruction::try_from(&self.regs.n) {
+            self.regs.n_sym = Some(symbolic);
+            Ok(()) // valid instruction
+        } else {
+            Err(self.invalid_opcode_alarm())
+        }
+    }
+
+    fn invalid_opcode_alarm(&self) -> Alarm {
+        Alarm::OCSAL(
+            self.regs.n,
+            format!("invalid opcode {:#o}", self.regs.n.opcode_number()),
+        )
+    }
+
+    /// Execute the instruction in the N register (i.e. the
+    /// instruction just fetched by fetch_instruction().  The P
+    /// register already points to the next instruction.
+    pub fn execute_instruction(&mut self, mem: &mut MemoryUnit) -> Result<(), Alarm> {
+        let sym = match &self.regs.n_sym {
+            None => return Err(self.invalid_opcode_alarm()),
+            Some(s) => s,
+        };
+        println!("Executing instruction {}...", sym);
+        use Opcode::*;
+        match sym.opcode() {
+            Skx => self.op_skx(),
+            Dpx => self.op_dpx(mem),
+            Jmp => self.op_jmp(),
+	    Jpx => self.op_jpx(mem),
+	    Jnx => self.op_jnx(mem),
+	    Skm => self.op_skm(mem),
+	    Spg => self.op_spg(mem),
+            _ => {
+                return Err(Alarm::ROUNDTUITAL(format!(
+                    "The emulator does not yet implement opcode {}",
+                    sym.opcode()
+                )));
+            }
+        }
+        //Ok(())
+    }
+
+    fn get_config(&self) -> SystemConfiguration {
+        let cf = self.regs.n.configuration();
+        self.regs.get_f_mem(cf)
+    }
+
+    fn fetch_operand_from_address(
+        &self,
+        mem: &mut MemoryUnit,
+        operand_address: &Address,
+    ) -> Result<(Unsigned36Bit, ExtraBits), Alarm> {
+        let meta_op: MetaBitChange = match self.set_metabit_mode {
+            SetMetabit::Operands => MetaBitChange::Set,
+            _ => MetaBitChange::None,
+        };
+        match mem.fetch(operand_address, &meta_op) {
+            Ok((word, extra_bits)) => Ok((word, extra_bits)),
+            Err(MemoryOpFailure::NotMapped) => Err(Alarm::QSAL(
+		self.regs.n,
+                Unsigned36Bit::from(*operand_address),
+                format!(
+                    "memory unit indicated address {:o} is not mapped",
+                    operand_address
+                ),
+            )),
+            Err(MemoryOpFailure::ReadOnly) => unreachable!(),
+        }
+    }
+
+    /// Implements the SKX instruction (Opcode 012, User Handbook,
+    /// page 3-24).
+    pub fn op_skx(&mut self) -> Result<(), Alarm> {
+        let inst = &self.regs.n;
+        let j = inst.index_address();
+        // SKX does not cause an access to STUV memory; instead the
+        // operand is the full value of the operand and defer fields
+        // of the instruction.  This allows us to use SKX to mark a
+        // placeholder for use with TRAP 42.
+        let operand = inst.operand_address_and_defer_bit();
+        match u8::from(inst.configuration()) {
+            0o0 | 0o10 => {
+                if j != 0 {
+                    // Xj is fixed at 0.
+                    self.regs.set_index_register(j.into(), &operand.reinterpret_as_signed());
+                }
+                if j & 0o10 != 0 {
+                    self.regs.flags.raise(&j.into());
+                }
+                Ok(())
+            }
+	    0o1 => {
+                if j != 0 {  // Xj is fixed at 0.
+		    // Calculate -T
+		    let t_negated = Signed18Bit::ZERO.wrapping_sub(operand.reinterpret_as_signed());
+                    self.regs.set_index_register(j.into(), &t_negated);
+                }
+                Ok(())
+	    }
+            _ => Err(Alarm::ROUNDTUITAL(format!(
+                "SKX configuration {:#o} is not implemented yet",
+                inst.configuration()
+            ))),
+        }
+    }
+
+    fn memory_store_without_exchange(
+        &self,
+        mem: &mut MemoryUnit,
+        target: &Address,
+        value: &Unsigned36Bit,
+        meta_op: &MetaBitChange,
+    ) -> Result<(), Alarm> {
+	println!(
+	    "memory_store_without_exchange: write @{:>06o} <- {:o}",
+	    target,
+	    value,
+	);
+        mem.store(target, value, meta_op).map_err(|e| {
+            Alarm::QSAL(
+                self.regs.n,
+                Unsigned36Bit::from(*target),
+                format!("memory store to address {:#o} failed: {}", target, e,),
+            )
+        })
+    }
+
+    fn memory_store_with_exchange(
+        &self,
+        mem: &mut MemoryUnit,
+        target: &Address,
+        value: &Unsigned36Bit,
+        existing: &Unsigned36Bit,
+        meta_op: &MetaBitChange,
+    ) -> Result<(), Alarm> {
+        self.memory_store_without_exchange(
+            mem,
+            target,
+            &exchanged_value(&self.get_config(), value, existing),
+            meta_op,
+        )
+    }
+
+    fn operand_address_with_optional_defer_and_index(
+        self: &mut ControlUnit,
+        mem: &mut MemoryUnit,
+    ) -> Result<Address, Alarm> {
+	self.resolve_operand_address(mem, None)
+    }
+
+    fn resolve_operand_address(
+        self: &mut ControlUnit,
+        mem: &mut MemoryUnit,
+	mut initial_index_override: Option<Unsigned6Bit>,
+    ) -> Result<Address, Alarm> {
+	// The deferred addressing process may be performed more than
+	// once, in other words it is a loop.  This is explained in
+	// section 9-7, "DEFERRED ADDRESSING CYCLES" of Volume 2 of
+	// the technical manual.
+	while let OperandAddress::Deferred(physical) = self.regs.n.operand_address() {
+	    // In effect, this loop emulates a non-ultimate deferred
+	    // address cycle.
+	    //
+            // According to the description of PK3 on page 5-9 of the
+            // User handbook, the deferred address calculation and
+            // indexing occurs in (i.e. by modifying) the N register.
+	    //
+	    // JPX and JNX seem to be handled differently, but I don't
+	    // think I understand exactly what the difference is
+	    // supposed to be.
+	    //
+	    // (Vol 2, page 12-9): It should also be noted that the
+	    // N₂.₉ bit is presented as an input to the X Adder only
+	    // when no deferred address cycles are called for.  When
+	    // PI¹₂, the input to the X Adder from the N₂.₉ position
+	    // is forced to appear as a ZERO.
+
+            println!(
+		"deferred addressing: deferred address is {:o}",
+		&physical
+            );
+            let meta_op = match self.set_metabit_mode {
+		SetMetabit::DeferredAddresses => MetaBitChange::Set,
+		_ => MetaBitChange::None,
+            };
+            let fetched = match mem.fetch(&physical, &meta_op) {
+                Err(e) => {
+		    return Err(Alarm::QSAL(
+			self.regs.n,
+			Unsigned36Bit::from(physical),
+			format!("address {:#o} out of range while fetching deferred address: {}", &physical, e),
+		    ));
+                }
+                Ok((word, _meta)) => {
+		    // I think it's likely that the TX2 should perform
+		    // indexation on deferred addreses.  This idea is
+		    // based on the fact that the left subword of
+		    // deferred addresses used in plugboard programs
+		    // can be nonzero, and on the fact that the
+		    // description of the SKM instruction notes "SKM
+		    // is therefore non-indexable except through
+		    // deferred addressing".
+		    let (left, right) = subword::split_halves(word);
+		    println!(
+			"deferred addressing: fetched full word is {:o},,{:o}; using {:o} as the final address",
+			&left, &right, &right);
+		    Address::from(right)
+                }
+	    };
+
+	    // We update the lower 18 bits (i.e. right half) of N with
+	    // the value we just loaded from memory.
+	    let unchanged_left = subword::left_half(Unsigned36Bit::from(self.regs.n));
+	    self.update_n_register(subword::join_halves(unchanged_left, Unsigned18Bit::from(fetched)))?;
+	}
+	let physical_address = match self.regs.n.operand_address() {
+	    // Cannot be a deferred address any more, as loop above
+	    // loops until the address is not deferred.
+	    OperandAddress::Deferred(_) => unreachable!(),
+	    OperandAddress::Direct(physical_address) => physical_address,
+	};
+	// The defer bit in N is (now) not set.  Emulate a regular or
+	// ultimate address cycle.  That is, add the index value to
+	// the operand address.  While the index_address field in the
+	// instruction is unsigned (following the conventions in the
+	// assembly source), the indexation operation itself uses
+	// signed arithmetic (see the explanation in the doc comment
+	// for the IndexBy trait).
+	let j = match initial_index_override {
+	    None => self.regs.n.index_address(),
+	    Some(overridden) => {
+		let j = overridden;
+		initial_index_override = None;
+		j
+	    },
+	};
+	let delta = self.regs.get_index_register(j); // this is Xj.
+
+        // A number of things expect that the "most recent data (memory)
+        // reference" is saved in register Q.  14JMP (a.k.a. JPQ) makes
+        // use of this, for example.
+        self.regs.q = physical_address.index_by(delta);
+
+        // TODO: figure out if other parts of the system documentation
+        // definitely expect the physical operand address to be
+        // written back into the N register (in a
+        // programmer-detectable way).
+        Ok(self.regs.q)
+    }
+
+    /// Implements the DPX instruction (Opcode 016, User Handbook,
+    /// page 3-16).
+    pub fn op_dpx(&mut self, mem: &mut MemoryUnit) -> Result<(), Alarm> {
+	let j = self.regs.n.index_address();
+        let xj: Unsigned36Bit = sign_extend_index_value(&self.regs.get_index_register(j));
+        let target: Address = self.operand_address_with_optional_defer_and_index(mem)?;
+        let (dest, _meta) = self.fetch_operand_from_address(mem, &target)?;
+        self.memory_store_with_exchange(
+            mem,
+            &target,
+            &xj,
+            &dest,
+            &MetaBitChange::None,
+        )
+    }
+
+    fn dismiss_unless_held(&mut self) {
+	if !self.regs.n.is_held() {
+            if let Some(current_seq) = self.regs.k {
+                self.regs.flags.lower(&current_seq);
+		self.regs.current_sequence_is_runnable = false;
+            }
+	}
+    }
+
+    /// Implements the JMP opcode and its variations (all of which are unconditional jumps).
+    pub fn op_jmp(&mut self) -> Result<(), Alarm> {
+        // For JMP the configuration field in the instruction controls
+        // the behaviour of the instruction, without involving
+        // a load from F-memory.
+        fn nonzero(value: Unsigned5Bit) -> bool {
+            !value.is_zero()
+        }
+        let cf = self.regs.n.configuration();
+        let dismiss = nonzero(cf & 0b10000_u8);
+        let save_q = nonzero(cf & 0b01000_u8);
+        let savep_e = nonzero(cf & 0b00100_u8);
+        let savep_ix = nonzero(cf & 0b00010_u8);
+        let indexed = nonzero(cf & 0b00001_u8);
+        let left: Unsigned18Bit = if save_q {
+            Unsigned18Bit::from(self.regs.q)
+        } else {
+            subword::left_half(self.regs.e)
+        };
+        let right: Unsigned18Bit = if savep_e {
+            Unsigned18Bit::from(self.regs.p)
+        } else {
+            subword::right_half(self.regs.e)
+        };
+        self.regs.e = subword::join_halves(left, right);
+
+        if savep_ix {
+            let j = self.regs.n.index_address();
+            if j != 0 {
+                // Xj is fixed at 0.
+                let p = self.regs.p;
+                self.regs.set_index_register_from_address(j.into(), &p);
+            }
+        }
+
+        let physical: Address = match self.regs.n.operand_address() {
+            OperandAddress::Deferred(_) => {
+                // TODO: I don't know whether this is allowed or
+                // not, but if we disallow this for now, we can
+                // use any resulting error to identify cases where
+                // this is in fact used.
+                return Err(Alarm::PSAL(
+                    u32::from(self.regs.n.operand_address_and_defer_bit()),
+                    format!(
+                        "JMP target has deferred address {:#o}",
+                        self.regs.n.operand_address()
+                    ),
+                ));
+            }
+            OperandAddress::Direct(phys) => phys,
+        };
+
+	let new_pc: Address = if indexed {
+	    physical.index_by(self.regs.n.index_address().reinterpret_as_signed())
+        } else {
+	    physical
+        };
+	self.set_program_counter(ProgramCounterChange::Jump(new_pc));
+        if dismiss {
+	    self.dismiss_unless_held();
+        }
+        Ok(())
+    }
+
+    /// Implements the JPX (jump on positive index) opcode (06).
+    pub fn op_jpx(&mut self, mem: &mut MemoryUnit) -> Result<(), Alarm> {
+	let is_positive_address = |xj: &Signed18Bit| xj.is_positive();
+	self.impl_op_jpx_jnx(is_positive_address, mem)
+    }
+
+    /// Implements the JNX (jump on positive index) opcode (07).
+    pub fn op_jnx(&mut self, mem: &mut MemoryUnit) -> Result<(), Alarm> {
+	let is_negative_address = |xj: &Signed18Bit| xj.is_negative();
+	self.impl_op_jpx_jnx(is_negative_address, mem)
+    }
+
+    // Implements JPX (opcode 06) and JNX.  Note that these opcodes
+    // handle deferred addressing in a unique way.  This is described
+    // on page 5-9 of the User Handbook:
+    //
+    // EXCEPT when the operation is JNX or JPX (codes 6 and 7), for on
+    // these two operations the right half of N is used for the sign
+    // extended index increment (18 bits).  (BUT if the JNX or JPX is
+    // deferred, the increment is not addded until PK3 so N is not
+    // changed during PK1).
+    pub fn impl_op_jpx_jnx<F: FnOnce(&Signed18Bit)->bool>(
+	&mut self,
+	predicate: F,
+	mem: &mut MemoryUnit,
+    ) -> Result<(), Alarm> {
+	let dismiss = !self.regs.n.is_held();
+	let j = self.regs.n.index_address();
+	let xj = self.regs.get_index_register(j);
+	let do_jump: bool = predicate(&xj);
+
+	// Compute the jump target (which possibly involves indexing)
+	// before modifying Xj.  See note 3 on page 3-27 of the User
+	// Handbook, which says
+	//
+	// The address of a deferred JNX or JPX is completely
+	// determined before the index register is changed.  Therefore
+	// a ⁻¹JPXₐ|ₐ S would jump to Sₐ as defined by the original
+	// contents of Xₐ - if it jumps at all.
+        let target: Address = self.resolve_operand_address(mem, Some(Unsigned6Bit::ZERO))?;
+	let cf: Signed5Bit = self.regs.n.configuration().reinterpret_as_signed();
+	let new_xj: Signed18Bit = xj.wrapping_add(Signed18Bit::from(cf));
+	self.regs.set_index_register(j, &new_xj);
+
+	if do_jump {
+            self.dismiss_unless_held();
+            self.regs.e = subword::join_halves(subword::left_half(self.regs.e),
+					       Unsigned18Bit::from(self.regs.p));
+            self.set_program_counter(ProgramCounterChange::Jump(target));
+	}
+        if dismiss {
+            if let Some(current_seq) = self.regs.k {
+                self.regs.flags.lower(&current_seq);
+		self.regs.current_sequence_is_runnable = false;
+            }
+        }
+        Ok(())
+     }
+
+    /// Implement the SKM instruction.  This has a number of
+    /// supernumerary mnemonics.  The index address field of the
+    /// instruction identifies which bit (within the target word) to
+    /// operate on, and the instruction configuration value determines
+    /// both how to manipulate that bit, and what to do on the basis
+    /// of its original value.
+    ///
+    /// The SKM instruction is documented on pages 7-34 and 7-35 of
+    /// the User Handbook.
+    pub fn op_skm(&mut self, mem: &mut MemoryUnit) -> Result<(), Alarm> {
+	let bit = index_address_to_bit_selection(self.regs.n.index_address());
+	// Determine the operand address; any initial deferred cycle
+	// must use 0 as the indexation, as the index address of the
+	// SKM instruction is used to identify the bit to operate on.
+	let target = self.resolve_operand_address(mem, Some(Unsigned6Bit::ZERO))?;
+	let cf: u8 = u8::from(self.regs.n.configuration());
+	let change: WordChange = WordChange {
+	    bit,
+	    bitop: match cf & 0b11 {
+		0b00 => None,
+		0b01 => Some(BitChange::Flip),
+		0b10 => Some(BitChange::Clear),
+		0b11 => Some(BitChange::Set),
+		_ => unreachable!(),
+	    },
+	    cycle: cf & 0b100 != 0,
+	};
+	let prev_bit_value: Option<bool> = match mem.change_bit(&target, &change) {
+	    Ok(prev) => prev,
+	    Err(MemoryOpFailure::NotMapped) => {
+		return Err(Alarm::QSAL(
+		    self.regs.n,
+		    target.into(),
+                    format!(
+			"SKM instruction attempted to access address {:o} but it is not mapped",
+			target,
+                    ),
+		));
+	    }
+	    Err(MemoryOpFailure::ReadOnly) => {
+		return Err(Alarm::QSAL(
+		    self.regs.n,
+		    target.into(),
+                    format!(
+			"SKM instruction attempted to modify (instruction configuration={:o}) a read-only location {:o}",
+			cf,
+			target,
+                    ),
+		));
+	    }
+	};
+	let skip: bool = if let Some(prevbit) = prev_bit_value {
+	    match (cf >> 3) & 3 {
+		0b00 => false,
+		0b01 => true,
+		0b10 => !prevbit,
+		0b11 => prevbit,
+		_ => unreachable!(),
+	    }
+	} else {
+	    // The index address specified a nonexistent bit
+	    // (e.g. 1.0) and so we do not perform a skip.
+	    false
+	};
+	// The location of the currently executing instruction is referred to by M4
+	// as '#'.  The next instruction would be '#+1' and that's where the P register
+	// currently points.  But "skip" means to set P=#+2.
+	if skip {
+	    self.set_program_counter(ProgramCounterChange::CounterUpdate);
+	}
+	Ok(())
+    }
+
+    pub fn op_spg(&mut self, mem: &mut MemoryUnit) -> Result<(), Alarm> {
+        let c = usize::from(self.regs.n.configuration());
+	let target = self.operand_address_with_optional_defer_and_index(mem)?;
+        let (word, _meta) = self.fetch_operand_from_address(mem, &target)?;
+	for (quarter_number, cfg_value) in subword::quarters(word).iter().enumerate() {
+	    self.regs.f_memory[c + quarter_number] = (*cfg_value).into();
+	}
+	Ok(())
+    }
+}

--- a/cpu/src/exchanger.rs
+++ b/cpu/src/exchanger.rs
@@ -1,0 +1,1116 @@
+//! The Exchange Element governs data exchange between memory (via the
+//! M register) and other parts of the central compute unit (including
+//! the arithmetic element) via the E register.
+//!
+//! The way in which the exchange element behaves is governed by the
+//! "System Configuration" which is a 9-bit value loaded from the
+//! F-memory.  Which specific value is loaded from the F-memory is
+//! determined by the 5-bit configuration field within the current
+//! instruction; the instruction is loaded into the N register).
+//!
+//! The standard set-up of the F-memory is described in Table 7-2 of
+//! the User Guide.
+use base::prelude::*;
+
+use std::fmt::{self, Display, Formatter, Octal};
+
+// QuarterActivity has a 1 where a quarter is active (unlike the sense
+// in the configuration values, which are 0 for active).  Quarters in
+// QuarterActivity are numbered from 0.
+#[derive(Clone, Copy, Debug)]
+pub struct QuarterActivity(u8);
+
+impl QuarterActivity {
+    pub fn new(bits: u8) -> QuarterActivity {
+        assert_eq!(bits & !0b1111, 0);
+        QuarterActivity(bits)
+    }
+
+    pub fn is_active(&self, q: &u8) -> bool {
+        assert!(*q < 4, "invalid quarter {}", q);
+        let mask = 1 << *q;
+        self.0 & mask != 0
+    }
+
+    pub fn first_active_quarter(&self) -> u8 {
+        self.0.trailing_zeros() as u8
+    }
+
+    pub fn masked_by(&self, mask: u8) -> QuarterActivity {
+        QuarterActivity::new(self.0 & mask)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0 == 0
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Permutation {
+    P0 = 0,
+    P1,
+    P2,
+    P3,
+    P4,
+    P5,
+    P6,
+    P7,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SubwordForm {
+    FullWord = 0, // 36
+    Halves = 1,   // 18, 18
+    ThreeOne = 2, // 27, 9
+    Quarters = 3, //
+}
+
+/// The SystemConfiguration value specifies a global state of the
+/// computer which determines how the AE (in modern wording,
+/// arithmetic unit) communicates with memory.  The basic outline is
+/// given in Fig. 9 (page 20) of "A Functional Description of the
+/// Lincoln TX-2 Computer" by John M. Frankovitch and H. Philip
+/// Peterson.  A more complete description (inclusing the
+/// corresponding F-memory values) is given in tables 7-2 and 7-2A of
+/// the TX-2 User's Handbook (pp 192-193 in my PDF copy).
+///
+/// The system configuration is a 9-bit value.  While Frankovitch and
+/// Peterson describe most significant bit as being spare, table 7-2
+/// appears to use it.
+///
+/// Figure 12-39 ("Configuration Block Diagram") (page 250) in Volume
+/// 2 of the TX-2 Technical manual describes how a word from the CF
+/// memory (a QKIRcf value) is decoded into permutation, activity
+/// (which quarters are active) and fracture (which quarters are
+/// considered to be separate).
+#[derive(Clone, Copy, Debug)]
+pub struct SystemConfiguration(Unsigned9Bit);
+
+impl From<u8> for SystemConfiguration {
+    fn from(n: u8) -> SystemConfiguration {
+        SystemConfiguration(Unsigned9Bit::from(n))
+    }
+}
+
+impl From<Unsigned9Bit> for SystemConfiguration {
+    fn from(n: Unsigned9Bit) -> SystemConfiguration {
+        SystemConfiguration(n)
+    }
+}
+
+impl PartialEq for SystemConfiguration {
+    fn eq(&self, other: &SystemConfiguration) -> bool {
+        self.0.eq(&other.0)
+    }
+}
+
+impl Display for SystemConfiguration {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+        Octal::fmt(&self.0, f)
+    }
+}
+
+impl Octal for SystemConfiguration {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+        Octal::fmt(&self.0, f)
+    }
+}
+
+impl SystemConfiguration {
+    pub fn zero() -> SystemConfiguration {
+        SystemConfiguration(Unsigned9Bit::ZERO)
+    }
+
+    fn permutation(&self) -> Permutation {
+        match u16::from(self.0) & 0b111 {
+            0 => Permutation::P0,
+            1 => Permutation::P1,
+            2 => Permutation::P2,
+            3 => Permutation::P3,
+            4 => Permutation::P4,
+            5 => Permutation::P5,
+            6 => Permutation::P6,
+            7 => Permutation::P7,
+            _ => unreachable!(),
+        }
+    }
+
+    /// Extract a QuarterActivity value from the activity field of a system
+    /// configuration value.
+    ///
+    /// Active quarters are signaled by a 0 in the appropriate bit
+    /// position of the system configuration value.  A 1 signals that
+    /// the corresponding quarter is inactive.
+    ///
+    /// The mapping between configuration values and which quarter is
+    /// active is given in Table 12-4 in the technical manual (volume
+    /// 2, page 12-22).
+    ///
+    fn active_quarters(&self) -> QuarterActivity {
+        // CF7 CF6 CF5 CF4
+        //   x   x   x   0 => ACT 1
+        //   x   x   0   x => ACT 2
+        //   x   0   x   x => ACT3
+        //   0   x   x   x => ACT4
+        //
+        // These bit values are not mutually exclusive, so for example
+        // 0010 means that quarters 4, 3 and 1 are active.
+        let act_field: u16 = (!(u16::from(self.0) >> 3)) & 0b1111;
+        let result = QuarterActivity::new(act_field as u8);
+        println!(
+            "active_quarters: system configuration {:>03o} -> result {:?}",
+            self, result
+        );
+        result
+    }
+
+    fn subword_form(&self) -> SubwordForm {
+        const MASK: u16 = 0o3 << 7;
+        match u16::from(self.0) & MASK {
+            0b000000000 => SubwordForm::FullWord, // 36
+            0b010000000 => SubwordForm::Halves,   // 18,18
+            0b100000000 => SubwordForm::ThreeOne, // 27,9
+            0b110000000 => SubwordForm::Quarters, // 9,9,9,9
+            _ => unreachable!(),
+        }
+    }
+}
+
+/// The standard configuration set of F-memory, taken from table 7-2
+/// (marked "OLD") of the TX-2 User's Guide (October 1961).
+const STANDARD_CONFIG: [u16; 32] = [
+    0o000, 0o340, 0o342, 0o760, 0o761, 0o762, 0o763, 0o410, 0o411, 0o140, 0o142, 0o160, 0o161,
+    0o162, 0o163, 0o202, 0o200, 0o230, 0o232, 0o732, 0o733, 0o730, 0o731, 0o605, 0o600, 0o750,
+    0o670, 0o320, 0o333, 0o330, 0o331, 0o604,
+];
+
+#[cfg(test)]
+macro_rules! assert_octal_eq {
+    ($left:expr, $right:expr $(,)?) => {{
+        match (&$left, &$right) {
+            (left_val, right_val) => {
+                if !(*left_val == *right_val) {
+                    panic!(
+                        "Assertion failed: {:#>012o} != {:>#012o}",
+                        left_val, right_val
+                    );
+                }
+            }
+        }
+    }};
+}
+
+enum QuarterSource {
+    // In all cases where we perform sign extension, the sign bit we
+    // are extendng comes from an active subword.  This means that we
+    // never need to copy a result bit from one place in the result to
+    // another, because it can always be described as coming from the
+    // source.  This is useful for cases like system configuration
+    // 0o325, which is P5, ACT1, ACT3, subword form (18,18).  Here bit
+    // 1.9 is copied from 4.9 and then sign-extended through quarter
+    // 2.
+    UseSource(i8),
+    SignExtendOrUnchanged, // depending on subword form
+}
+
+/// Compute the quarter number (starting at 0) of the source word from
+/// which the values for `target_quarter` (also starting at 0) would
+/// be taken if it were active.
+///
+/// Permutation behaviour is described in section 12-6.4 of Volume 2
+/// of the Technical Manual.
+fn permutation_source(permutation: &Permutation, target_quarter: u8) -> u8 {
+    match permutation {
+        Permutation::P0 => (target_quarter + 0) % 4,
+        Permutation::P1 => (target_quarter + 1) % 4,
+        Permutation::P2 => (target_quarter + 2) % 4,
+        Permutation::P3 => (target_quarter + 3) % 4,
+        Permutation::P4 => target_quarter ^ 0b01,
+        Permutation::P5 => target_quarter ^ 0b11,
+        Permutation::P6 => match target_quarter {
+            3 => 2,
+            2 => 1,
+            1 => 3,
+            0 => 0,
+            _ => unreachable!(),
+        },
+        Permutation::P7 => match target_quarter {
+            3 => 1,
+            2 => 3,
+            1 => 2,
+            0 => 0,
+            _ => unreachable!(),
+        },
+    }
+}
+
+// TODO: add a unit test for sign extension in partially-active
+// subwords, based on the example in Figures 12-41, 12-42 (technical
+// manual, volume 2).
+
+fn quarter_mask(n: u8) -> u64 {
+    assert!(n < 4);
+    0o777 << (n * 9)
+}
+
+fn apply_sign(word: u64, quarter_number_from: u8, quarter_number_to: u8) -> u64 {
+    let signbit = word & (0o300 << (quarter_number_from * 9));
+    let mask = quarter_mask(quarter_number_to);
+    if signbit == 0 {
+        word & !mask
+    } else {
+        word | mask
+    }
+}
+
+fn sign_extend_quarters(w: &Unsigned36Bit, active_quarters: QuarterActivity, quarters: &[u8]) -> Unsigned36Bit {
+    let mut word: Unsigned36Bit = *w;
+    if !active_quarters.is_empty() {
+        let first_active = active_quarters.first_active_quarter();
+        assert!(first_active < 4);
+        let mut last_active = first_active;
+        for q in quarters {
+            if active_quarters.is_active(q) {
+                last_active = *q;
+            } else {
+                let mut w64 = u64::from(word); // TODO: eliminate conversion
+                w64 = apply_sign(w64, last_active, *q);
+                word = Unsigned36Bit::try_from(w64).unwrap(); // TODO: eliminate conversion
+            }
+        }
+    }
+    word
+}
+
+pub fn sign_extend(form: &SubwordForm, mut word: Unsigned36Bit, active: QuarterActivity) -> Unsigned36Bit {
+    match form {
+        SubwordForm::FullWord => {
+            let first = active.first_active_quarter();
+            let quarters = &[first, (first + 1) % 4, (first + 2) % 4, (first + 3) % 4];
+            sign_extend_quarters(&word, active, quarters)
+        }
+        SubwordForm::ThreeOne => {
+            fn next(q: u8) -> u8 {
+                match q {
+                    1 | 2 => q + 1,
+                    3 => 1,
+                    _ => unreachable!(),
+                }
+            }
+            if active.is_empty() {
+                word
+            } else {
+                let first = active.first_active_quarter();
+                let quarters = &[first, next(first), next(next(first))];
+                sign_extend_quarters(&word, active.masked_by(0b1110), quarters)
+            }
+        }
+        SubwordForm::Halves => {
+            let a = active.masked_by(0b0011);
+            if !a.is_empty() {
+                fn next_right(q: u8) -> u8 {
+                    match q {
+                        0 => 1,
+                        1 => 0,
+                        _ => unreachable!(),
+                    }
+                }
+                let first = a.first_active_quarter();
+                word = sign_extend_quarters(&word, a, &[first, next_right(first)]);
+            }
+            let a = active.masked_by(0b1100);
+            if !a.is_empty() {
+                fn next_left(q: u8) -> u8 {
+                    match q {
+                        3 => 2,
+                        2 => 3,
+                        _ => unreachable!(),
+                    }
+                }
+                let first = a.first_active_quarter();
+                word = sign_extend_quarters(
+                    &word,
+                    active.masked_by(0b1100),
+                    &[first, next_left(first)],
+                );
+            }
+            word
+        }
+        SubwordForm::Quarters => word,
+    }
+}
+
+#[test]
+fn test_sign_extend_full_word() {
+    use SubwordForm::*;
+
+    fn word(val: u64) -> Unsigned36Bit {
+        Unsigned36Bit::try_from(val).expect("valid test data")
+    }
+
+    // When all quarters are active, sign extension should make no difference.
+    assert_octal_eq!(
+        sign_extend(&FullWord, Unsigned36Bit::from(0_u8), QuarterActivity::new(0b1111)),
+        word(0)
+    );
+    assert_octal_eq!(
+        sign_extend(
+            &FullWord,
+            word(0o300_000_000_000_u64),
+            QuarterActivity::new(0b1111)
+        ),
+        word(0o300_000_000_000_u64)
+    );
+    assert_octal_eq!(
+        sign_extend(
+            &FullWord,
+            word(0o000_300_000_000_u64),
+            QuarterActivity::new(0b1111)
+        ),
+        word(0o000_300_000_000_u64)
+    );
+    assert_octal_eq!(
+        sign_extend(
+            &FullWord,
+            word(0o000_000_300_000_u64),
+            QuarterActivity::new(0b1111)
+        ),
+        word(0o000_000_300_000_u64)
+    );
+    assert_octal_eq!(
+        sign_extend(
+            &FullWord,
+            word(0o000_000_000_300_u64),
+            QuarterActivity::new(0b1111)
+        ),
+        word(0o000_000_000_300_u64)
+    );
+
+    // If no quarters are active, there is nothing to sign-extend from, so sign extension is a no-op.
+    assert_octal_eq!(
+        sign_extend(
+            &FullWord,
+            word(0o444333222111_u64),
+            QuarterActivity::new(0b0000)
+        ),
+        word(0o444333222111_u64)
+    );
+
+    // Sign-extending a positive quantity into a quarter should zero it.
+    assert_octal_eq!(
+        sign_extend(
+            &FullWord,
+            word(0o727_003_002_001_u64),
+            QuarterActivity::new(0b0111)
+        ),
+        word(0o000_003_002_001_u64)
+    );
+    assert_octal_eq!(
+        sign_extend(
+            &FullWord,
+            word(0o004_727_002_001_u64),
+            QuarterActivity::new(0b1011)
+        ),
+        word(0o004_000_002_001_u64)
+    );
+    assert_octal_eq!(
+        sign_extend(
+            &FullWord,
+            word(0o004_003_727_001_u64),
+            QuarterActivity::new(0b1101)
+        ),
+        word(0o004_003_000_001_u64)
+    );
+    assert_octal_eq!(
+        sign_extend(
+            &FullWord,
+            word(0o004_003_002_727_u64),
+            QuarterActivity::new(0b1110)
+        ),
+        word(0o004_003_002_000_u64)
+    );
+
+    // Sign-extending a negative quantity into a quarter should fill it with ones.
+    assert_octal_eq!(
+        sign_extend(
+            &FullWord,
+            word(0o272_303_002_001_u64),
+            QuarterActivity::new(0b0111)
+        ),
+        word(0o777_303_002_001_u64)
+    );
+    assert_octal_eq!(
+        sign_extend(
+            &FullWord,
+            word(0o004_272_302_001_u64),
+            QuarterActivity::new(0b1011)
+        ),
+        word(0o004_777_302_001_u64)
+    );
+    assert_octal_eq!(
+        sign_extend(
+            &FullWord,
+            word(0o004_003_272_301_u64),
+            QuarterActivity::new(0b1101)
+        ),
+        word(0o004_003_777_301_u64)
+    );
+    assert_octal_eq!(
+        sign_extend(
+            &FullWord,
+            word(0o304_003_002_272_u64),
+            QuarterActivity::new(0b1110)
+        ),
+        word(0o304_003_002_777_u64)
+    );
+
+    // We should be able to sign-extend over two consecutive quarters.
+    assert_octal_eq!(
+        sign_extend(
+            &FullWord,
+            word(0o727_003_002_727_u64),
+            QuarterActivity::new(0b0110)
+        ),
+        word(0o000_003_002_000_u64)
+    );
+    assert_octal_eq!(
+        sign_extend(
+            &FullWord,
+            word(0o727_727_002_001_u64),
+            QuarterActivity::new(0b0011)
+        ),
+        word(0o000_000_002_001_u64)
+    );
+    assert_octal_eq!(
+        sign_extend(
+            &FullWord,
+            word(0o004_727_727_001_u64),
+            QuarterActivity::new(0b1001)
+        ),
+        word(0o004_000_000_001_u64)
+    );
+    assert_octal_eq!(
+        sign_extend(
+            &FullWord,
+            word(0o004_003_727_727_u64),
+            QuarterActivity::new(0b1100)
+        ),
+        word(0o004_003_000_000_u64)
+    );
+
+    // We should be able to sign-extend a positive value over three consecutive quarters.
+    assert_octal_eq!(
+        sign_extend(
+            &FullWord,
+            word(0o727_727_727_001_u64),
+            QuarterActivity::new(0b0001)
+        ),
+        word(0o000_000_000_001_u64)
+    );
+    assert_octal_eq!(
+        sign_extend(
+            &FullWord,
+            word(0o727_727_002_727_u64),
+            QuarterActivity::new(0b0010)
+        ),
+        word(0o000_000_002_000_u64)
+    );
+    assert_octal_eq!(
+        sign_extend(
+            &FullWord,
+            word(0o727_003_727_727_u64),
+            QuarterActivity::new(0b0100)
+        ),
+        word(0o000_003_000_000_u64),
+    );
+    assert_octal_eq!(
+        sign_extend(
+            &FullWord,
+            word(0o004_727_727_727_u64),
+            QuarterActivity::new(0b1000)
+        ),
+        word(0o004_000_000_000_u64)
+    );
+
+    // We should be able to sign-extend a negative value over three consecutive quarters.
+    assert_octal_eq!(
+        sign_extend(
+            &FullWord,
+            word(0o727_727_727_301_u64),
+            QuarterActivity::new(0b0001)
+        ),
+        word(0o777_777_777_301_u64)
+    );
+    assert_octal_eq!(
+        sign_extend(
+            &FullWord,
+            word(0o727_727_302_727_u64),
+            QuarterActivity::new(0b0010)
+        ),
+        word(0o777_777_302_777_u64)
+    );
+    assert_octal_eq!(
+        sign_extend(
+            &FullWord,
+            word(0o727_303_727_727_u64),
+            QuarterActivity::new(0b0100)
+        ),
+        word(0o777_303_777_777_u64)
+    );
+    assert_octal_eq!(
+        sign_extend(
+            &FullWord,
+            word(0o304_727_727_727_u64),
+            QuarterActivity::new(0b1000)
+        ),
+        word(0o304_777_777_777_u64),
+    );
+}
+
+#[test]
+fn test_sign_extend_halves() {
+    use SubwordForm::*;
+    fn word(val: u64) -> Unsigned36Bit {
+        Unsigned36Bit::try_from(val).expect("valid test data")
+    }
+
+    // When all quarters are active, sign extension should make no difference.
+    assert_octal_eq!(
+        sign_extend(&Halves, word(0), QuarterActivity::new(0b1111)),
+        word(0)
+    );
+    assert_octal_eq!(
+        sign_extend(
+            &Halves,
+            word(0o300_000_000_000_u64),
+            QuarterActivity::new(0b1111)
+        ),
+        word(0o300_000_000_000_u64)
+    );
+    assert_octal_eq!(
+        sign_extend(
+            &Halves,
+            word(0o000_300_000_000),
+            QuarterActivity::new(0b1111)
+        ),
+        word(0o000_300_000_000),
+    );
+    assert_octal_eq!(
+        sign_extend(
+            &Halves,
+            word(0o000_000_300_000_u64),
+            QuarterActivity::new(0b1111)
+        ),
+        word(0o000_000_300_000_u64)
+    );
+    assert_octal_eq!(
+        sign_extend(
+            &Halves,
+            word(0o000_000_000_300_u64),
+            QuarterActivity::new(0b1111)
+        ),
+        word(0o000_000_000_300_u64)
+    );
+
+    // If no quarters are active, there is nothing to sign-extend from, so sign extension is a no-op.
+    assert_octal_eq!(
+        sign_extend(
+            &Halves,
+            word(0o444333222111_u64),
+            QuarterActivity::new(0b0000)
+        ),
+        word(0o444333222111_u64)
+    );
+
+    // Sign-extending a positive quantity into a quarter should zero it.
+    assert_octal_eq!(
+        sign_extend(
+            &Halves,
+            word(0o004_003_002_001_u64),
+            QuarterActivity::new(0b0101)
+        ),
+        word(0o000_003_000_001_u64)
+    );
+    assert_octal_eq!(
+        sign_extend(
+            &Halves,
+            word(0o004_003_002_001_u64),
+            QuarterActivity::new(0b0001)
+        ),
+        word(0o004_003_000_001_u64)
+    );
+    assert_octal_eq!(
+        sign_extend(
+            &Halves,
+            word(0o004_003_002_001_u64),
+            QuarterActivity::new(0b1010)
+        ),
+        word(0o004_000_002_000_u64)
+    );
+    assert_octal_eq!(
+        sign_extend(
+            &Halves,
+            word(0o004_003_002_001_u64),
+            QuarterActivity::new(0b0110)
+        ),
+        word(0o000_003_002_000_u64)
+    );
+
+    // Sign-extending a negative quantity into a quarter should fill it with ones.
+    assert_octal_eq!(
+        sign_extend(
+            &Halves,
+            word(0o004_303_302_001_u64),
+            QuarterActivity::new(0b0110)
+        ),
+        word(0o777_303_302_777_u64)
+    );
+    assert_octal_eq!(
+        sign_extend(
+            &Halves,
+            word(0o304_003_302_001_u64),
+            QuarterActivity::new(0b1010)
+        ),
+        word(0o304_777_302_777_u64)
+    );
+    assert_octal_eq!(
+        sign_extend(
+            &Halves,
+            word(0o004_303_002_301_u64),
+            QuarterActivity::new(0b0101)
+        ),
+        word(0o777_303_777_301_u64)
+    );
+    assert_octal_eq!(
+        sign_extend(
+            &Halves,
+            word(0o004_003_002_301_u64),
+            QuarterActivity::new(0b0001)
+        ),
+        word(0o004_003_777_301_u64)
+    );
+
+    // We should not be able to sign-extend over two consecutive
+    // quarters (because the halves are only two quarters long).
+    assert_octal_eq!(
+        sign_extend(
+            &Halves,
+            word(0o004_003_002_001_u64),
+            QuarterActivity::new(0b0001)
+        ),
+        word(0o004_003_000_001_u64)
+    );
+    assert_octal_eq!(
+        sign_extend(
+            &Halves,
+            word(0o004_003_002_001_u64),
+            QuarterActivity::new(0b0010)
+        ),
+        word(0o004_003_002_000_u64)
+    );
+    assert_octal_eq!(
+        sign_extend(
+            &Halves,
+            word(0o004_003_002_001_u64),
+            QuarterActivity::new(0b0100)
+        ),
+        word(0o000_003_002_001_u64)
+    );
+    assert_octal_eq!(
+        sign_extend(
+            &Halves,
+            word(0o004_003_002_001_u64),
+            QuarterActivity::new(0b1000)
+        ),
+        word(0o004_000_002_001_u64)
+    );
+}
+
+// TODO: add tests for (27,9) and maybe (9,9,9,9).
+
+/// Determine which quarter of `source` gets permuted into
+/// `target_quarter` (numbered from zero), without regard to activity.
+/// Return the value of that quarter, shifted down into the lowest
+/// quarter.
+fn fetch_permuted_quarter(permutation: &Permutation, target_quarter: u8, source: &u64) -> u64 {
+    let source_quarter = permutation_source(permutation, target_quarter);
+    (source & quarter_mask(source_quarter)) >> (source_quarter * 9)
+}
+
+#[test]
+fn test_fetch_permuted_quarter() {
+    assert_octal_eq!(
+        fetch_permuted_quarter(&Permutation::P0, 2, &0o444333222111),
+        0o333
+    );
+}
+
+/// Copy bits from `source` to `dest`, permuting them according to
+/// `permutation`.  Only active quarters are modified.
+fn permute(
+    permutation: &Permutation,
+    active_quarters: &QuarterActivity,
+    source: &Unsigned36Bit,
+    dest: &Unsigned36Bit,
+) -> Unsigned36Bit {
+    let mut result: u64 = (*dest).into();
+    let source_bits: u64 = u64::from(*source);
+    for target_quarter in 0_u8..4_u8 {
+        assert!(target_quarter < 4, "invalid quarter {}", target_quarter); // TODO: remove pointless assertion
+        if active_quarters.is_active(&target_quarter) {
+            // `value` will be the value from the quarter we want,
+            // shifted to the correct position.
+            let value = fetch_permuted_quarter(permutation, target_quarter, &source_bits)
+                << (target_quarter * 9);
+            let target_mask: u64 = quarter_mask(target_quarter);
+            result &= !target_mask;
+            result |= target_mask & value;
+        }
+    }
+    Unsigned36Bit::try_from(result).unwrap()
+}
+
+#[test]
+fn test_permute() {
+    fn word(val: u64) -> Unsigned36Bit {
+        Unsigned36Bit::try_from(val).expect("valid test data")
+    }
+
+    assert_octal_eq!(
+        permute(
+            &Permutation::P0,
+            &QuarterActivity::new(0b1111),
+            &word(0o444333222111_u64),
+            &word(0o777666555444_u64),
+        ),
+        word(0o444333222111_u64),
+    );
+    assert_octal_eq!(
+        permute(
+            &Permutation::P0,
+            &QuarterActivity::new(0b1110),
+            &word(0o444333222111_u64),
+            &word(0o777666555444_u64),
+        ),
+        word(0o444333222444_u64),
+    );
+}
+
+/// Perform an exchange operation; that is, emulate the operation of
+/// the exchange unit. The operation of this unit is described in
+/// section 12 (volume 2) of the Technical Manual.
+pub fn exchanged_value(cfg: &SystemConfiguration, source: &Unsigned36Bit, dest: &Unsigned36Bit) -> Unsigned36Bit {
+    let active_quarters = cfg.active_quarters();
+    let permutation = cfg.permutation();
+    let permuted_target = permute(&permutation, &active_quarters, source, dest);
+    sign_extend(&cfg.subword_form(), permuted_target, active_quarters)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::memory::get_standard_plugboard;
+
+    fn standard_plugboard_f_memory_settings() -> Vec<u16> {
+        let mut result = Vec::with_capacity(0o040);
+        let plugboard = get_standard_plugboard();
+        dbg!(&plugboard);
+        for (i, spg_word) in plugboard.iter().enumerate() {
+            for quarter in 0..4 {
+                let index = (i * 4) + quarter;
+                let value: u64 = u64::from(*spg_word) >> (quarter * 9);
+                let value: u16 = (value & 0o777) as u16;
+                println!("F-memory index {:>03o} = {:>03o}", index, value);
+                result.push(value);
+            }
+        }
+        result
+    }
+
+    #[test]
+    fn test_system_configuration_standard_config() {
+        #[derive(Debug)]
+        struct Expectation {
+            config: Unsigned9Bit,
+            perm: Permutation,
+            form: SubwordForm,
+            active: u8,
+        }
+        fn configval(n: u16) -> Unsigned9Bit {
+            Unsigned9Bit::try_from(n).expect("valid test data")
+        }
+        use Permutation::*;
+        use SubwordForm::*;
+        let cases: [Expectation; 32] = [
+            // should be size 32 when we're ready
+            // Indexes 000 to 003
+            Expectation {
+                config: configval(0),
+                // (4,3,2,1) -> (4,3,2,1)
+                perm: P0,
+                form: FullWord,
+                active: 0b1111,
+            },
+            Expectation {
+                config: configval(0o340),
+                // (2,1)->(2,1) i.e. R->R
+                perm: P0,
+                form: Halves,
+                active: 0b0011,
+            },
+            Expectation {
+                config: configval(0o342),
+                // (4,3) -> (2, 1), i.e. L->R
+                perm: P2,
+                form: Halves,
+                active: 0b0011,
+            },
+            Expectation {
+                config: configval(0o760),
+                // (1) -> (1)
+                perm: P0,
+                form: Quarters,
+                active: 0b0001,
+            },
+            // Indexes 004 to 007
+            Expectation {
+                config: configval(0o761),
+                // (2) -> (1)
+                perm: P1,
+                form: Quarters,
+                active: 0b0001,
+            },
+            Expectation {
+                config: configval(0o762),
+                // (3) -> (1)
+                perm: P2,
+                form: Quarters,
+                active: 0b0001,
+            },
+            Expectation {
+                config: configval(0o763),
+                // (4) -> (1)
+                perm: P3,
+                form: Quarters,
+                active: 0b0001,
+            },
+            Expectation {
+                config: configval(0o410),
+                // (4,3,2) -> (4,3,2)
+                perm: P0,
+                form: ThreeOne,
+                active: 0b1110,
+            },
+            // Indexes 010 to 013
+            Expectation {
+                config: configval(0o411),
+                // (1,4,3) -> (4,3,2)
+                perm: P1,
+                form: ThreeOne,
+                active: 0b1110,
+            },
+            Expectation {
+                config: configval(0o140),
+                // (2,1) -> (2,1), i.e. R->R and sign extend into L
+                perm: P0,
+                form: FullWord,
+                active: 0b0011,
+            },
+            Expectation {
+                config: configval(0o142),
+                // (4,3) -> (2,1), i.e. L->R and sign extend into L
+                perm: P2,
+                form: FullWord,
+                active: 0b0011,
+            },
+            Expectation {
+                config: configval(0o160),
+                // (1) -> (1) and sign extend into full word
+                perm: P0,
+                form: FullWord,
+                active: 0b0001,
+            },
+            // Indexes 014 to 017
+            Expectation {
+                config: configval(0o161),
+                // (2) -> (1) and sign extend into full word
+                perm: P1,
+                form: FullWord,
+                active: 0b0001,
+            },
+            Expectation {
+                config: configval(0o162),
+                // (3) -> (1) and sign extend into full word
+                perm: P2,
+                form: FullWord,
+                active: 0b0001,
+            },
+            Expectation {
+                config: configval(0o163),
+                // (4) -> (1) and sign extend into full word
+                perm: P3,
+                form: FullWord,
+                active: 0b0001,
+            },
+            Expectation {
+                config: configval(0o202),
+                //  (4,3),(2,1) -> (2,1),(4,3), i.e. L,R -> R,L
+                perm: P2,
+                form: Halves,
+                active: 0b1111,
+            },
+            // Indexes 020 to 023
+            Expectation {
+                config: configval(0o200),
+                // (4,3),(2,1) -> (4,3),(2,1), i.e. L,R->L,R
+                perm: P0,
+                form: Halves,
+                active: 0b1111,
+            },
+            Expectation {
+                config: configval(0o230),
+                // (4,3) -> (4,3), i.e L->L
+                perm: P0,
+                form: Halves,
+                active: 0b1100,
+            },
+            Expectation {
+                config: configval(0o232),
+                // (2,1) -> (4,3), i.e. R->L
+                perm: P2,
+                form: Halves,
+                active: 0b1100,
+            },
+            Expectation {
+                config: configval(0o732),
+                // (1) -> (3)
+                perm: P2,
+                form: Quarters,
+                active: 0b0100,
+            },
+            // Indexes 024 to 027
+            Expectation {
+                config: configval(0o733),
+                // (2) -> (3)
+                perm: P3,
+                form: Quarters,
+                active: 0b0100,
+            },
+            Expectation {
+                config: configval(0o730),
+                // (3) -> (3)
+                perm: P0,
+                form: Quarters,
+                active: 0b0100,
+            },
+            Expectation {
+                config: configval(0o731),
+                // (4) -> (3)
+                perm: P1,
+                form: Quarters,
+                active: 0b0100,
+            },
+            Expectation {
+                config: configval(0o605),
+                // (4),(3),(2),(1) -> (1),(2),(3),(4)
+                perm: P5,
+                form: Quarters,
+                active: 0b1111,
+            },
+            // Indexes 030 to 033
+            Expectation {
+                config: configval(0o600),
+                // (4),(3),(2),(1) -> (4),(3),(2),(1)
+                perm: P0,
+                form: Quarters,
+                active: 0b1111,
+            },
+            Expectation {
+                config: configval(0o750),
+                // (2) -> (2)
+                perm: P0,
+                form: Quarters,
+                active: 0b0010,
+            },
+            Expectation {
+                config: configval(0o670),
+                // (4) -> (4)
+                perm: P0,
+                form: Quarters,
+                active: 0b1000,
+            },
+            Expectation {
+                config: configval(0o320),
+                // (3),(1) -> (3),(1); sign extend (1) into L, (3) into R
+                perm: P0,
+                form: Halves,
+                active: 0b0101,
+            },
+            // Indexes 034 to 037
+            Expectation {
+                config: configval(0o333),
+                // (2) -> (3) and sign extend into L
+                perm: P3,
+                form: Halves,
+                active: 0b0100,
+            },
+            Expectation {
+                config: configval(0o330),
+                // (3) -> (3) and sign extend into L
+                perm: P0,
+                form: Halves,
+                active: 0b0100,
+            },
+            Expectation {
+                config: configval(0o331),
+                // (4) -> (3) and sign extend into L
+                perm: P1,
+                form: Halves,
+                active: 0b0100,
+            },
+            Expectation {
+                config: configval(0o604),
+                // (4),(3),(2),(1) -> (3),(4),(1),(2)
+                perm: P4,
+                form: Quarters,
+                active: 0b1111,
+            },
+        ];
+
+        // Validate the system configuration value in the current test
+        // case against the values from table 7-2 in the user
+        // handbook.
+        for (index, case) in cases.iter().enumerate() {
+            let cfg = Unsigned9Bit::try_from(STANDARD_CONFIG[index]).expect("valid test data");
+            assert_eq!(
+                cfg, case.config,
+                "config in test case does not match standard config"
+            );
+        }
+
+        let f_memory = standard_plugboard_f_memory_settings();
+        for (index, case) in cases.iter().enumerate() {
+            let expected = case.config;
+            let got = f_memory[index];
+            assert_eq!(
+                expected, got,
+                "config at index {} in test case does not match standard config: {:o} != {:o}",
+                index, expected, got,
+            );
+        }
+
+        for (index, case) in cases.iter().enumerate() {
+            let sysconfig = SystemConfiguration(case.config);
+            assert_eq!(
+                sysconfig.permutation(),
+                case.perm,
+                "non-matching permutation"
+            );
+            assert_eq!(
+                sysconfig.subword_form(),
+                case.form,
+                "non-matching subword form"
+            );
+        }
+    }
+}

--- a/cpu/src/lib.rs
+++ b/cpu/src/lib.rs
@@ -6,3 +6,7 @@ mod control;
 mod exchanger;
 mod memory;
 mod memorymap;
+
+pub use alarm::Alarm;
+pub use control::{ControlUnit, ResetMode};
+pub use memory::{MemoryConfiguration, MemoryUnit};

--- a/cpu/src/lib.rs
+++ b/cpu/src/lib.rs
@@ -2,4 +2,5 @@
 //! and the exchange unit.
 
 mod alarm;
+mod memory;
 mod memorymap;

--- a/cpu/src/lib.rs
+++ b/cpu/src/lib.rs
@@ -2,6 +2,7 @@
 //! and the exchange unit.
 
 mod alarm;
+mod control;
 mod exchanger;
 mod memory;
 mod memorymap;

--- a/cpu/src/lib.rs
+++ b/cpu/src/lib.rs
@@ -1,0 +1,4 @@
+//! This module decodes instructions and emulates the arithmetic unit
+//! and the exchange unit.
+
+mod alarm;

--- a/cpu/src/lib.rs
+++ b/cpu/src/lib.rs
@@ -2,5 +2,6 @@
 //! and the exchange unit.
 
 mod alarm;
+mod exchanger;
 mod memory;
 mod memorymap;

--- a/cpu/src/lib.rs
+++ b/cpu/src/lib.rs
@@ -2,3 +2,4 @@
 //! and the exchange unit.
 
 mod alarm;
+mod memorymap;

--- a/cpu/src/memory.rs
+++ b/cpu/src/memory.rs
@@ -1,0 +1,543 @@
+// This module emulates the TX-2's STUV memory.
+///
+/// STUV memory is memory-mapped.  That is, each location (which the
+/// documentation describes as a "register") has an address between 0
+/// and 377777 octal, inclusive.  Even registers that we would
+/// describe today as being "CPU registers" (i.e. registers A-E) have
+/// addresses.  See memorymap.rs for details of the memory map.
+///
+/// Other memories (for example X memory and F memory) are emulated in
+/// control.rs.
+///
+/// The TX-2 uses 36-bit words.  We use Unsigned36Bit (defined in
+/// onescomplement/unsigned.rs) to represent this.  The TX-2 has a
+/// number of memories which have differing widths.  Its STUV memory
+/// (which today we might describe as "main memory") has 38 bitplanes.
+/// 36 for each of the value bits, plus two more:
+///
+/// - Meta bit; this can be read or written using special
+///   memory-related instructions.  Programs can also set up a mode of
+///   operation in which various operations (e.g.  loading an operand
+///   or instruction) causes a meta bit to be set.
+/// - Parity bit: value maintained and checked by the system.
+///   Readable via the SKM instruction.  The emulator behaves as if
+///   parity errors never occur.
+///
+use std::fmt::{self, Debug, Formatter};
+
+use crate::memorymap::*;
+use base::prelude::*;
+
+#[derive(Clone, Copy)]
+struct MemoryWord(u64); // Not public.
+const WORD_BITS: u64 = 0x0FFFFFFFFF;
+const META_BIT: u64 = 0x1000000000;
+
+impl Debug for MemoryWord {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+        write!(f, "{:>012o}", self.0)
+    }
+}
+
+fn compute_extra_bits(w: u64) -> ExtraBits {
+    let parity: bool = match w.count_ones() & 1 {
+	0 => false,
+	1 => true,
+	_ => unreachable!(),
+    };
+    let meta: bool = w & META_BIT != 0;
+    ExtraBits {
+	meta,
+	parity,
+    }
+}
+
+impl From<&MemoryWord> for (Unsigned36Bit, ExtraBits) {
+    fn from(w: &MemoryWord) -> (Unsigned36Bit, ExtraBits) {
+        let valuebits: u64 = w.0 & WORD_BITS;
+        (Unsigned36Bit::try_from(valuebits).unwrap(), compute_extra_bits(w.0))
+    }
+}
+
+impl From<&mut MemoryWord> for (Unsigned36Bit, ExtraBits) {
+    fn from(w: &mut MemoryWord) -> (Unsigned36Bit, ExtraBits) {
+        let valuebits: u64 = w.0 & WORD_BITS;
+        (Unsigned36Bit::try_from(valuebits).unwrap(), compute_extra_bits(w.0))
+    }
+}
+
+#[test]
+fn test_meta_bit_position() {
+    println!("Meta bit is {:>012o}", &META_BIT);
+    assert_eq!(
+        36,
+        META_BIT.trailing_zeros(),
+        "meta bit should immediately follow data bits"
+    );
+    assert_eq!(
+        1,
+        META_BIT.count_ones(),
+        "there should be only one meta bit"
+    );
+}
+
+#[test]
+fn test_word_bits() {
+    dbg!(&WORD_BITS);
+    println!("WORD_BITS is {:>012o}", &WORD_BITS);
+    assert_eq!(
+        0,
+        WORD_BITS.trailing_zeros(),
+        "word bits should begin at the least significant bit"
+    );
+    assert_eq!(36, WORD_BITS.count_ones(), "words should be 36 bits wide");
+}
+
+impl MemoryWord {
+    fn set_meta_bit(&mut self, value: &bool) {
+        if *value {
+            self.0 |= META_BIT
+        } else {
+            self.0 &= !META_BIT;
+        }
+    }
+
+    fn flip_meta_bit(&mut self) {
+	self.0 ^= META_BIT
+    }
+
+    /// Update the value of the word in memory without changing the
+    /// meta bit.
+    fn set_value(&mut self, value: &Unsigned36Bit) {
+        self.0 = (self.0 & META_BIT) | (u64::from(*value) & WORD_BITS);
+    }
+}
+
+impl Default for MemoryWord {
+    fn default() -> MemoryWord {
+        MemoryWord(0)
+    }
+}
+
+fn default_filled_memory_vec(size: u32) -> Vec<MemoryWord> {
+    let size: usize = size.try_into().expect("unexpectedly large memory element");
+    let mut result = Vec::with_capacity(size);
+    while result.len() < size {
+        result.push(MemoryWord::default());
+    }
+    result
+}
+
+#[derive(Debug)]
+pub struct MemoryUnit {
+    s_memory: Vec<MemoryWord>,
+    t_memory: Vec<MemoryWord>,
+    u_memory: Option<Vec<MemoryWord>>,
+    v_memory: VMemory,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum MemoryAccess {
+    Read,
+    Write,
+}
+
+pub enum MemoryDecode {
+    S(usize),
+    T(usize),
+    U(usize),
+    V(usize),
+}
+
+fn decode(address: &Address) -> Option<MemoryDecode> {
+    // MemoryDecode32 is a workaround for the fact that our address
+    // arithmetic uses u32 but we want to return an offset of type
+    // usize.
+    enum MemoryDecode32 {
+        S(u32),
+        T(u32),
+        U(u32),
+        V(u32),
+    }
+    let addr: u32 = u32::from(address);
+    let decoded = {
+        if addr < T_MEMORY_START {
+            Some(MemoryDecode32::S(addr - S_MEMORY_START))
+        } else if addr < U_MEMORY_START {
+            Some(MemoryDecode32::T(addr - T_MEMORY_START))
+        } else if addr < (U_MEMORY_START + U_MEMORY_SIZE) {
+            Some(MemoryDecode32::U(addr - U_MEMORY_START))
+        } else if addr < V_MEMORY_START {
+            // This address is valid, but this memory region (after the U
+            // memory, before the V memory) is not mapped to anything.
+            None
+        } else if (V_MEMORY_START..V_MEMORY_START + V_MEMORY_SIZE).contains(&addr) {
+            Some(MemoryDecode32::V(addr - V_MEMORY_START))
+        } else {
+            // The end of V memory is the highest address it is possible
+            // to form in 17 bits.  So, it should not be possible to form
+            // an invalid address in an Address struct, so we should not
+            // be able to get here.
+            panic!(
+                "Access to memory address {:?} should be impossible",
+                &address
+            );
+        }
+    };
+    // This code should not panic since the input Address type should
+    // not allow an address which is large enough that it can't be
+    // represented in a usize value.  The largest offset which the
+    // code above should compute is the last address of S-memory, and
+    // that fits into 16 bits.
+    decoded.map(|d| match d {
+        MemoryDecode32::S(addr) => MemoryDecode::S(addr.try_into().unwrap()),
+        MemoryDecode32::T(addr) => MemoryDecode::T(addr.try_into().unwrap()),
+        MemoryDecode32::U(addr) => MemoryDecode::U(addr.try_into().unwrap()),
+        MemoryDecode32::V(addr) => MemoryDecode::V(addr.try_into().unwrap()),
+    })
+}
+
+pub struct MemoryConfiguration {
+    pub with_u_memory: bool,
+}
+
+impl MemoryUnit {
+    pub fn new(config: &MemoryConfiguration) -> MemoryUnit {
+        MemoryUnit {
+            s_memory: default_filled_memory_vec(S_MEMORY_SIZE),
+            t_memory: default_filled_memory_vec(T_MEMORY_SIZE),
+            u_memory: if config.with_u_memory {
+                Some(default_filled_memory_vec(U_MEMORY_SIZE))
+            } else {
+                None
+            },
+            v_memory: VMemory::new(),
+        }
+    }
+
+    fn access(
+        &mut self,
+        access_type: &MemoryAccess,
+        addr: &Address,
+    ) -> Result<Option<&mut MemoryWord>, MemoryOpFailure> {
+        match decode(addr) {
+            Some(MemoryDecode::S(offset)) => Ok(Some(&mut self.s_memory[offset])),
+            Some(MemoryDecode::T(offset)) => Ok(Some(&mut self.s_memory[offset])),
+            Some(MemoryDecode::U(offset)) => {
+                if let Some(u) = &mut self.u_memory {
+                    Ok(Some(&mut u[offset]))
+                } else {
+                    Err(MemoryOpFailure::NotMapped)
+                }
+            }
+            Some(MemoryDecode::V(_)) => self.v_memory.access(access_type, addr),
+            None => Err(MemoryOpFailure::NotMapped),
+        }
+    }
+}
+
+/// Implement the heart of the change_bit() operation used by the SKM instruction.
+fn change_word(mem_word: &mut MemoryWord, op: &WordChange) -> Option<bool> {
+    // As the documentation for the SKM instruction (user
+    // handbook, page 3-35) explains, we perform the
+    // possible bit change before the possible rotate.
+    let prev: Option<bool> = match (op.bit.quarter, op.bit.bitpos) {
+	(_, 0) => None,
+	(quarter, shift@ 1..=10) => {
+	    let mask: u64 = if shift < 10 {
+		1 << ((u8::from(quarter) * 9) + (shift-1))
+	    } else {
+		META_BIT
+	    };
+	    let old_value: bool = (mem_word.0 & mask) != 0;
+	    match op.bitop {
+		None => (),
+		Some(BitChange::Clear) => mem_word.0 &= !mask,
+		Some(BitChange::Set) => mem_word.0 |= mask,
+		Some(BitChange::Flip) => mem_word.0 ^= mask,
+	    }
+	    Some(old_value)
+	}
+	// 11 is the partiy bit 12 is the computed parity.
+	// Both a read-only, but I don't think an attempt
+	// to modify them trips an alarm (at least, I
+	// can't see any mention of this in the SKM
+	// documentation).
+	(_, 11|12) => {
+	    let (_wordval, extra_bits): (Unsigned36Bit, ExtraBits) = mem_word.into();
+	    Some(extra_bits.parity)
+	}
+	_ => unreachable!(),
+    };
+    if op.cycle {
+	let (value, _extra) = mem_word.into();
+	mem_word.set_value(&(value >> 1));
+    }
+    prev
+}
+
+
+impl MemoryMapped for MemoryUnit {
+    fn fetch(
+        &mut self,
+        addr: &Address,
+        side_effect: &MetaBitChange,
+    ) -> Result<(Unsigned36Bit, ExtraBits), MemoryOpFailure> {
+        if u32::from(addr) >= V_MEMORY_START {
+	    // The description of the SKM instruction doesn't state
+	    // explicitly that SKM works on V-memory, but since
+	    // arithmetic unit registers are mapped to it, it would
+	    // make sense.  However, there are clearly other locations
+	    // in V memory (e.g. the plugboard) that we can't cycle.
+	    if *side_effect != MetaBitChange::None {
+                // Changng meta bits in V memory is not allowed,
+                // see the longer comment in the store() method.
+                return Err(MemoryOpFailure::ReadOnly);
+            }
+        }
+        match self.access(&MemoryAccess::Read, addr) {
+            Err(e) => {
+                return Err(e);
+            }
+	    Ok(None) => unreachable!(),
+            Ok(Some(mem_word)) => {
+                let result = mem_word.into();
+		match side_effect {
+		    MetaBitChange::None => (),
+		    MetaBitChange::Set => mem_word.set_meta_bit(&true),
+		}
+                Ok(result)
+            }
+        }
+    }
+
+    fn store(
+        &mut self,
+        addr: &Address,
+        value: &Unsigned36Bit,
+        meta: &MetaBitChange,
+    ) -> Result<(), MemoryOpFailure> {
+        if u32::from(addr) >= V_MEMORY_START && matches!(meta, MetaBitChange::Set) {
+            // This is an attempt to set a meta bit in V memory.
+            //
+            // The meta bits of registers A..E cannot be
+            // set by the "set metabits of.." modes of IOS 42.
+            //
+            // According to page 5-23 of the User Handbook, attempts
+            // to set the metabit of registers via the MKC instruction
+            // actually set the meta bit of the M register.  But I
+            // don't know how that manifests to the programmer as an
+            // observable behaviour.
+            //
+            // For now we generate a failure in the hope that we will
+            // eventually find a program which performs this action,
+            // and study it to discover the actual behaviour of the
+            // TX-2 that the program expects.
+            //
+            // The User Handbook also states that V-memory locations
+            // other than registers A-E cannot be written at all.
+            //return Err(MemoryOpFailure::ReadOnly);
+	    return Ok(());	// ignore the write.
+        }
+
+        // TODO: instructions are not allowed to write to V-memory
+        // (directly) though writes to registers are allowed.  For
+        // example EXA is permitted, I think.
+        match self.access(&MemoryAccess::Write, addr) {
+            Err(e) => {
+                return Err(e);
+            }
+	    Ok(None) => {
+		// Attempt to write to memory that cannot be written.
+		// We just ignore this.
+		return Ok(());
+	    }
+            Ok(Some(mem_word)) => {
+                mem_word.set_value(value);
+                match meta {
+		    MetaBitChange::None => (),
+		    MetaBitChange::Set => mem_word.set_meta_bit(&true),
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn change_bit(
+	&mut self,
+	addr: &Address,
+	op: &WordChange,
+    ) -> Result<Option<bool>, MemoryOpFailure> {
+	let memory_access: MemoryAccess = if op.will_mutate_memory() {
+	    MemoryAccess::Write
+	} else {
+	    MemoryAccess::Read
+	};
+	// If the memory address is not mapped at all, access will
+	// return Err, causing the next line to bail out of this
+	// function.
+	match self.access(&memory_access, addr)? {
+	    None => {
+		// The memory address is mapped to read-only memory.
+		// For example, plugboard memory.
+		//
+		// We downgrade the bit operation to be non-mutating,
+		// so that the outcome of the bit test is as it should
+		// be, but the memory-write is inhibited.
+		match self.access(&MemoryAccess::Read, addr)? {
+		    None => unreachable!(),
+		    Some(mem_word) => {
+			let downgraded_op = WordChange {
+			    bit: op.bit, // access the same bit
+			    bitop: None, // read-only
+			    cycle: false, // read-only
+			};
+			assert!(!downgraded_op.will_mutate_memory()); // should be read-only now
+			Ok(change_word(mem_word, &downgraded_op))
+		    }
+		}
+	    }
+            Some(mem_word) => Ok(change_word(mem_word, op)),
+	}
+    }
+}
+
+#[derive(Debug)]
+struct VMemory {
+    // Arithmetic registers have no meta bit.  Accesses which attempt
+    // to read the meta bit of registers A, B, , D, E actually return
+    // the meta bit in the M register.  This is briefly described on
+    // page 5-23 of the User Handbook.
+    //
+    // It says,
+    //
+    // "The data reference metabit (M^4.10) can be detected only when
+    // set (just as N^4.10 above).  Note that it can be changed
+    // without a memory reference for it serves as the metabit of the
+    // A, B, C, D, and E registers. (i.e., MKC_4.10 A or MKC_4.10 B
+    // will change bit 4.10 of M."
+    //
+    // V memory in general does behave as if it has a meta bit.  For
+    // example, there is a push-button on the console that acts as the
+    // value of the meta bit of the shaft encoder register.
+    //
+    // Hence we store registers as MemoryWord values.  It's not clear
+    // to me yet how to implement the behaviour described on page
+    // 5-23.
+    a_register: MemoryWord,
+    b_register: MemoryWord,
+    c_register: MemoryWord,
+    d_register: MemoryWord,
+    e_register: MemoryWord,
+    // TODO: shaft encoders
+    // TODO: external input register
+    // TODO: RTC
+    // TODO: CODABO start points
+    plugboard: [MemoryWord; 32],
+}
+
+const fn standard_plugboard_internal() -> [MemoryWord; 32] {
+    const fn mw(value: u64) -> MemoryWord {
+        MemoryWord(META_BIT | (value & WORD_BITS))
+    }
+    // This data has not yet been double-checked and no tests
+    // validate it, so it might be quite wrong.
+    [
+        // Plugboard memory starts with Plugboard B at 0o3777740.
+        //
+        // F-memory settings; these are verified against the
+        // information from Table 7-2 by a test in the exchanger code.
+        mw(0o_760342_340000),
+        mw(0o_410763_762761),
+        mw(0o_160142_140411),
+        mw(0o_202163_162161),
+        mw(0o_732232_230200),
+        mw(0o_605731_730733),
+        mw(0o_320670_750600),
+        mw(0o_604331_330333),
+        // 0o377750: standard program to load the F-memory settings
+        // (this is not verified by the test in the exchanger code).
+        mw(0o_002200_377740),
+        mw(0o_042200_377741),
+        mw(0o_102200_377742),
+        mw(0o_142200_377743),
+        mw(0o_202200_377744),
+        mw(0o_242200_377745),
+        mw(0o_302200_377746),
+        mw(0o_342200_377747),
+        // Plugboard A, 0o377760-0o377777
+        // 0o0377760: Standard program: read in reader leader from paper tape
+        mw(0o011254_000023),
+        mw(0o001252_377763),
+        mw(0o210452_030106),
+        mw(0o001253_000005),
+        mw(0o405754_000026),
+        mw(0o760653_377764),
+        mw(0o410754_377763),
+        mw(0o140500_000003),
+        // 0o0377770: Standard program: clear memory
+        mw(0o001277_207777),
+        mw(0o001677_777776),
+        mw(0o140500_377773),
+        mw(0o001200_777610),
+        mw(0o760677_377771),
+        mw(0o301712_377744),
+        mw(0o000077_000000),
+        mw(0o140500_377750),
+    ]
+}
+
+pub fn get_standard_plugboard() -> Vec<Unsigned36Bit> {
+    standard_plugboard_internal()
+        .iter()
+        .map(|mw| mw.into())
+        .map(|(word, _meta)| word) // discard meta bits.
+        .collect()
+}
+
+impl VMemory {
+    fn new() -> VMemory {
+        VMemory {
+            a_register: MemoryWord::default(),
+            b_register: MemoryWord::default(),
+            c_register: MemoryWord::default(),
+            d_register: MemoryWord::default(),
+            e_register: MemoryWord::default(),
+            plugboard: standard_plugboard_internal(),
+        }
+    }
+
+    fn access(
+        &mut self,
+        access_type: &MemoryAccess,
+        addr: &Address,
+    ) -> Result<Option<&mut MemoryWord>, MemoryOpFailure> {
+        if access_type == &MemoryAccess::Write {
+	    // There appear to be some instructions which special-case
+	    // attempts to write to arithmetic unit registers, so we
+	    // may need a more sophisticated approach here.
+            return Ok(None);
+        }
+        match u32::from(addr) {
+            0o0377604 => Ok(Some(&mut self.a_register)),
+            0o0377605 => Ok(Some(&mut self.b_register)),
+            0o0377606 => Ok(Some(&mut self.c_register)),
+            0o0377607 => Ok(Some(&mut self.d_register)),
+            0o0377610 => Ok(Some(&mut self.e_register)),
+            // Shaft encoder, External Input Register, Real Time Clock
+            0o0377620 | 0o0377621 | 0o0377630 => todo!(),
+            0o0377710..=0o0377717 => todo!(), // Location of CODABO start points
+            addr @ 0o0377740..=0o0377777 => {
+                if let Ok(offset) = TryInto::<usize>::try_into(addr - 0o0377740) {
+                    Ok(Some(&mut self.plugboard[offset]))
+                } else {
+                    // Unreachable because the matched range is
+                    // not large enough to exceed the capacity of
+                    // usize (which we assume is at least 2^16).
+                    unreachable!()
+                }
+            }
+            _ => Err(MemoryOpFailure::NotMapped),
+        }
+    }
+}

--- a/cpu/src/memorymap.rs
+++ b/cpu/src/memorymap.rs
@@ -1,0 +1,330 @@
+use std::error;
+/// The TX2 has several different kinds of memory.  Some of it (known
+/// as S, T, U and V memories) are directly addressible.  These are
+/// described in Chapter 11 (Volume 2) of the technical manual.
+///
+/// Locations of S, U and T memory are taken from page 5-13 of the Users Handbook (which describes memory alarms).
+/// The location of V memory was deduced from the descrption of the plugboard in the user guide (which states that the plugboards end at 0377777) and the
+///
+/// The TX-2 also has other kinds of memory directly accessible to the
+/// programmer but which don't have memory addresses.  These are the
+/// F-memory and the X-memory.
+///
+/// Lastly there are some other memory stores which aren't accessible
+/// to the programmer.  These include the M and N registers (see
+/// below).
+///
+/// The memory system of the TX2 is described in chapters 4 and 11
+/// ("Memory Element") of the TX-2 Technical Manual.
+///
+/// I don't currently know of a surviving copy of chapter 4, since
+/// presumably it is in Volume 1 of the technical manual.  I don't
+/// have a copy of that.
+///
+/// # Addressible Memory
+///
+/// ## S Memory
+///
+/// 65536 words (according to the WJCC papers, 1957).
+///
+/// ## T Memory
+///
+/// Mapped at 0200000 to 0207777 (User Handbook, page 5-13).  Hence
+/// 4096 words.
+///
+/// ## U Memory
+///
+/// Mapped at 210000 to 217777 (User Handbook, page 5-13).  U memory
+/// is not implemented.
+///
+/// ## V Memory
+///
+/// V memory consists of two groups; static (Vᴛ) and flip-flop (Vꜰꜰ)
+/// memories.  Within the V memory there are the A (accumulator), B,
+/// C, D, E registers.  The V memory used only 7 bits of the P/Q
+/// (instruction/data address register) registers, meaning that it is
+/// 128 (200 octal) words in size.
+///
+/// ### Plugboard
+///
+/// Two plugboards (A and B) each contain 16 registers of 37 bits each
+/// (see section 11-7.1 in Volume 2 of the Technical Manual).  I'm not
+/// certain whether the plugboard locations have meta bits (or parity bits).
+///
+/// The standard "memory clear" boot program in Plugboard A appears to
+/// test the meta bit of location 377 744, which is in Plugboard A.
+/// This may simply be a convenient way of determining whether
+/// Plugboard B is set up before trying to execute code in it.
+///
+/// There is also a priority patch panel (technical manual volume 2,
+/// section 12-7.2) but that is likely not memory-mapped.
+///
+/// ### Toggle Switches
+///
+/// 24 registers of 37 bits each.  However, as of June 1961, only
+/// registers 0-17 were implemented.
+///
+/// ### Shaft Encoder
+///
+/// Mapped at 0377620.  Each shaft encoder emits a 9-bit number; four
+/// shaft encoders together emit a 36-bit number; a toggle switch
+/// provides the value of the meta bit (the user guide says this is a
+/// push-button).
+///
+/// ### Real-Time Clock
+///
+/// Mapped at 0377630.  36-bit counter plus meta bit.  Counter
+/// overflow (every 7.6 days) causes end-around carry.  Increments
+/// every 10 microseconds.
+///
+/// ### External Input Register
+///
+/// Mapped at 0377621.  Reflects the state of 37 external
+/// push-buttons.  Holding down a button produces a 1 bit.
+///
+/// ### Flip-Flop Memory
+///
+/// Registers A, C, C, D, E are memory-mapped.
+///
+/// The Programming Examples document, Program I states that A is
+/// mapped at address 0377740.  The Jul 1961 Users Handbook (page 3-3)
+/// states that it is mapped at address 0377604.  The user guide also
+/// shows (page 5-17) that 0377740 is the first address of Plugboard
+/// "B", so perhaps the arithmetic unit registers were moved to make
+/// room for a second plugboard.  In any case, we're going with the
+/// description in the Users Handbook.
+///
+/// A: 0377604
+/// B: 0377605
+/// C: 0377606
+/// D: 0377607
+/// E: 0377610
+///
+/// # Non-Addressible Memory
+///
+/// ## The M Register
+///
+/// The M register buffers memory stores and fetches.  Memory
+/// transfers which occur via the E register cause the current
+/// contents of the E register to be temporarily saved into the M
+/// register (see Technical Manual Volume 2, section 11-7.6).
+///
+/// ## The N register
+///
+/// The N register holds the current instruction.  During deferred
+/// address cycles, the N register holds the contents of a deferred
+/// operand load.
+///
+/// ## F-memory
+///
+/// The F-memory contains 32 locations, each 16 bits wide.
+///
+/// The F-memory stores sytem configuration values; the configuration
+/// field within each instruction is used as a lookup index into the
+/// F-memory. The system configuration fetched from the F-memory
+/// determines how memory transfers are carried out.  That is, how
+/// word quarters are permuted, which quarters are active and whether
+/// and how sign-extension ocurs ("subword form") on the value fetched
+/// or to be written.
+///
+/// The F-memory can be examined and modified by the programmer using
+/// the FLF and FLG (for read) and SPF and SPG (for write)
+/// instructions.  See pages 3-54 and 3-55 of the User Guide.
+///
+/// F-memory location 0 (corresponding to a zero-valued configuraiton
+/// field in the instruction: full 36-bit word form, no permutation,
+/// all quarters active) is not modifiable.
+///
+/// Decoding of F-memory values is summarised in Figure 12-39
+/// (Technical Manual, volume 2).
+///
+/// ## X-memory
+///
+/// The X memory is described in section 12-3 (Vol 2) of the Technical Manual.
+///
+/// The X memory is a 64 register 19-bit (magnetic core) memory.
+///
+/// ## Flag Register
+///
+/// The Flag register consists of 33 flip-flops, one for each
+/// sequence.  A value 1 in a bit indicates that the associated I/O
+/// unit requests attention.  See section 12-7.4 (volume 2) of the
+/// Technical Manual.
+///
+/// # Parity
+///
+/// Various stores in the TX-2 include a parity bit, but these are not
+/// all emulated because only some are programmer-detectable.  The SKM
+/// instruction (for example) allows the programmer to detect the
+/// state of a parity bit.   SKM does not allow the parity bit to be
+/// altered though, so we simply compute its value on the fly.
+///
+/// # Memory map
+///
+/// 0000000 Start of S memory (Technical Manual Volume 2, sec 12-2.8)
+/// 0177777 Last word of S memory (WJCC paper gives size as 65536 words)
+///
+/// 0200000 Start of T memory
+/// 0207777 Last location in T memory.
+/// 0210000 Start of U memory
+/// 0217777 Last location in U memory.
+///
+/// 0377600 Start of V-memory.
+///
+/// 0377604 A register
+/// 0377605 B register
+/// 0377606 C register
+/// 0377607 D register
+/// 0377610 E register
+///
+/// 0377620 Knob (Shaft Encoder) Register (User Handbook, 5-20)
+/// 0377621 External Input Register (User Handbook, 5-20)
+/// 0377630 Real Time Clock
+///
+/// 0377710 Location of CODABO start point 0
+/// 0377711 Location of CODABO start point 1
+/// 0377712 Location of CODABO start point 2
+/// 0377713 Location of CODABO start point 3
+/// 0377714 Location of CODABO start point 4
+/// 0377715 Location of CODABO start point 5
+/// 0377716 Location of CODABO start point 6
+/// 0377717 Location of CODABO start point 7
+///
+/// 0377740 Plugboard B memory start
+///         The plugboard program code is given
+///         in section 5-5.2 (page 5-27) of the
+///         User Handbook.
+/// 0377740 8 (Octal 10) words of data used by
+///         SPG instructions of the code at
+///         0377750 to set the standard configuration
+///         in F-memory.
+/// 0377750 Standard program, Set Configuration
+///         Loads the standard configuration into
+///         F-memory.  Then proceed to 0377760.
+/// 0377757 Last location in Plugboard B.
+/// 0377760 Plugboard A memory start
+/// 0377760 Standard program, Read In Reader Leader.
+///         Reads the first 21 words from paper tape
+///         into registers 3 through 24 of S-memory,
+///         then goes to register 3.
+///         The 21 words would be the "standard reader leader"
+///         of binary paper tapes.  The code for the standard
+///         reader leader is given in the User Handbook,
+///         section 5-5.2.
+/// 0377770 Standard program, Clear Memory / Smear Memory
+///         Sets all of S, T, U memory to 0 on the left
+///         and the address of itself on the right.
+///         Meta bits are not affected (User Guide 5-25).
+///         Automatically proceeds to 037750 (Set
+///         Configuration).
+/// 0377777 Plugboard A memory end; end of V memory; end of memory.
+use std::fmt::{Display, Error, Formatter};
+
+use base::prelude::*;
+use base::instruction::BitSelector;
+
+pub const S_MEMORY_START: u32 = 0o0000000;
+pub const S_MEMORY_SIZE: u32 = 1 + 0o0177777;
+pub const T_MEMORY_START: u32 = 0o0200000;
+pub const T_MEMORY_SIZE: u32 = 1 + 0o0207777 - 0o0200000;
+pub const U_MEMORY_START: u32 = 0o0210000;
+pub const U_MEMORY_SIZE: u32 = 1 + 0o0217777 - 0o0210000;
+pub const V_MEMORY_START: u32 = 0o0377600;
+pub const V_MEMORY_SIZE: u32 = 1 + 0o0377777 - 0o0377600;
+
+pub const STANDARD_PROGRAM_CLEAR_MEMORY: Address = Address::MAX.and(0o0377770_u32);
+
+#[derive(Debug)]
+pub enum MemoryOpFailure {
+    NotMapped,
+
+    // I have no idea whether the real TX-2 alarmed on writes to
+    // things that aren't really writeable (e.g. shaft encoder
+    // registers).  But by implemeting this we may be able to answer
+    // that question if some real (recovered) program writes to a
+    // location we assumed would be read-only.
+    ReadOnly,
+}
+
+impl Display for MemoryOpFailure {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
+        f.write_str(match self {
+            MemoryOpFailure::NotMapped => "address is not mapped to functioning memory",
+            MemoryOpFailure::ReadOnly => "address is mapped to read-only memory",
+        })
+    }
+}
+
+impl error::Error for MemoryOpFailure {}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum MetaBitChange {
+    None,
+    Set,
+}
+
+// Clear,
+// Flip,			// not used for fetch/store
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum BitChange {
+    Clear,
+    Set,
+    Flip
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct WordChange {
+    pub bit: BitSelector,
+    pub bitop: Option<BitChange>,
+    pub cycle: bool,
+}
+
+impl WordChange {
+    pub fn will_mutate_memory(&self) -> bool {
+	if self.cycle {
+	    true
+	} else if self.bitop.is_none() {
+	    false
+	} else {
+	    match self.bit {
+		BitSelector { quarter: _, bitpos: 0 } => false,
+		// bit positions 11 and 12 are parity and computed
+		// parity which we cannot change.
+		BitSelector { quarter: _, bitpos: 11|12 } => false,
+		_ => true,
+	    }
+	}
+    }
+}
+
+
+pub trait MemoryMapped {
+    // Fetch a word.
+    fn fetch(
+        &mut self,
+        addr: &Address,
+        meta: &MetaBitChange,
+    ) -> Result<(Unsigned36Bit, ExtraBits), MemoryOpFailure>;
+
+    // Store a word.
+    fn store(
+        &mut self,
+        addr: &Address,
+        value: &Unsigned36Bit,
+        meta: &MetaBitChange,
+    ) -> Result<(), MemoryOpFailure>;
+
+    // Mutate a bit in-place, returning its previous value.
+    fn change_bit(
+        &mut self,
+        addr: &Address,
+	op: &WordChange,
+    ) -> Result<Option<bool>, MemoryOpFailure>;
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct ExtraBits {
+    pub meta: bool,
+    pub parity: bool,
+}


### PR DESCRIPTION
This PR ads an emulator for the TX-2's memory, exchange element, and control element.

The implementation is a bit basic, but it executes the first part of the system's boot code.