### PR TITLE
Better I/O efficiency, implement alarm masking and deferred addressing indexation

### DIFF
--- a/OPEN-QUESTIONS.md
+++ b/OPEN-QUESTIONS.md
@@ -28,29 +28,9 @@
    registers A, B, C, D, E?  What are they, how do they behave?
 10. Is the plugboard which configures sequence priorities
     memory-mapped?  If yes, how does it appear?
-11. Does indexation occur during the intermedia deferred addressing
-    cycles?   What value is used (a value from the index register, or
-    the left-hand-side of the word loaded from the deferred location)?
-12. If you press "RESET 0" and the defer bit is set in the "RESET 0"
+11. If you press "RESET 0" and the defer bit is set in the "RESET 0"
     location, does a deferred addressing cycle occur (similarly for
 	resets 1-7)?
-
-### Deferred Addressing
-
-Is there any limit to the number of iterations of deferred address
-loads during deferred addressing?  That is, suppose memory contains
-
-|Address| Contents  |
-|-------|-----------|
-|0| 000  000 400 001|
-|1| 000  000 400 000|
-
-Then, I use `[0]` (that is, address 0 in deferred mode) in an
-instruction, will the deferred adressing operation loop forever
-between addresses 0 and 1?
-
-What use is made of the left halfword of the words loaded during
-deferred addressing?  Is this somehow used as an index value also?
 
 ## Instructions
 

--- a/OPEN-QUESTIONS.md
+++ b/OPEN-QUESTIONS.md
@@ -31,6 +31,9 @@
 11. Does indexation occur during the intermedia deferred addressing
     cycles?   What value is used (a value from the index register, or
     the left-hand-side of the word loaded from the deferred location)?
+12. If you press "RESET 0" and the defer bit is set in the "RESET 0"
+    location, does a deferred addressing cycle occur (similarly for
+	resets 1-7)?
 
 ### Deferred Addressing
 

--- a/base/src/onescomplement/unsigned/mod.rs
+++ b/base/src/onescomplement/unsigned/mod.rs
@@ -506,6 +506,22 @@ impl From<Unsigned5Bit> for Unsigned6Bit {
     }
 }
 
+impl TryFrom<Unsigned18Bit> for Unsigned6Bit {
+    type Error = ConversionFailed;
+    fn try_from(n: Unsigned18Bit) -> Result<Self, ConversionFailed> {
+        match u8::try_from(n.bits) {
+            Ok(n) => {
+                if n > Self::VALUE_BITS {
+                    Err(ConversionFailed::TooLarge)
+                } else {
+                    Ok(Self { bits: n })
+                }
+            }
+            Err(_) => Err(ConversionFailed::TooLarge),
+        }
+    }
+}
+
 ////////////////////////////////////////////////////////////////////////
 // Unsigned9Bit
 ////////////////////////////////////////////////////////////////////////

--- a/base/src/types.rs
+++ b/base/src/types.rs
@@ -4,6 +4,7 @@
 /// the CPU emulation, not here.
 use std::cmp::Ordering;
 use std::fmt::{Debug, Display, Error, Formatter, Octal};
+use std::hash::{Hash, Hasher};
 
 use crate::onescomplement::error::ConversionFailed;
 use crate::onescomplement::signed::{Signed18Bit, Signed5Bit, Signed6Bit};
@@ -265,6 +266,15 @@ impl PartialOrd for Address {
 impl PartialEq for Address {
     fn eq(&self, other: &Self) -> bool {
         self.0.eq(&other.0)
+    }
+}
+
+impl Hash for Address {
+    fn hash<H>(&self, h: &mut H)
+    where
+        H: Hasher,
+    {
+        self.0.hash(h)
     }
 }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -18,7 +18,7 @@ fn run(
     clk: &mut BasicClock,
     multiplier: Option<f64>,
 ) -> i32 {
-    control.codabo(&ResetMode::ResetTSP);
+    control.codabo(&ResetMode::ResetTSP, mem);
     if let Err(e) = run_until_alarm(control, mem, clk, multiplier) {
         event!(Level::ERROR, "Execution stopped: {}", e);
     }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -104,10 +104,10 @@ fn run_simulator() -> Result<(), Box<dyn std::error::Error>> {
     let speed_multiplier: Option<f64> = match matches.value_of("speed-multiplier") {
         None => {
             event!(
-                Level::INFO,
-                "No --speed-multiplier option specified, using multiplier of 1.0"
+                Level::WARN,
+                "No --speed-multiplier option specified, running at maximum speed"
             );
-            Some(1.0)
+            None
         }
         Some("MAX") => {
             event!(

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -35,6 +35,10 @@ impl TapeSequence {
     fn new(names: Vec<OsString>) -> TapeSequence {
         TapeSequence { pos: 0, names }
     }
+
+    fn is_empty(&self) -> bool {
+        self.names.is_empty()
+    }
 }
 
 impl TapeIterator for TapeSequence {
@@ -99,6 +103,12 @@ fn run_simulator() -> Result<(), Box<dyn std::error::Error>> {
             .map(OsString::from)
             .collect(),
     );
+    if tapes.is_empty() {
+        event!(
+            Level::WARN,
+            "No paper tapes were specified on the command line, so no program will be loaded"
+        );
+    }
     let petr = Box::new(Petr::new(Box::new(tapes)));
 
     let speed_multiplier: Option<f64> = match matches.value_of("speed-multiplier") {

--- a/cpu/Cargo.toml
+++ b/cpu/Cargo.toml
@@ -7,7 +7,8 @@ edition = "2021"
 
 [dependencies]
 base = { path = "../base" }
-tracing = "0.1"
+tracing = "0.1" # MIT license
+keyed_priority_queue = "0.4.1"	# MIT license
 
 [lib]
 name = "cpu"

--- a/cpu/src/alarm.rs
+++ b/cpu/src/alarm.rs
@@ -4,13 +4,28 @@ use std::fmt::{self, Display, Formatter};
 use base::instruction::Instruction;
 use base::prelude::*;
 
+#[derive(Debug)]
+pub enum BadMemOp {
+    Read(Unsigned36Bit),
+    Write(Unsigned36Bit),
+}
+
+impl Display for BadMemOp {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+        match self {
+            BadMemOp::Read(addr) => write!(f, "memory read from {:>013o} failed", addr),
+            BadMemOp::Write(addr) => write!(f, "memory write to {:>013o} failed", addr),
+        }
+    }
+}
+
 // Alarms from User's Handbook section 5-2.2
 #[derive(Debug)]
 pub enum Alarm {
-    PSAL(u32, String),                        // Program counter set to illegal address
-    OCSAL(Instruction, String),               // Illegal instruction was read into N register
-    QSAL(Instruction, Unsigned36Bit, String), // Q register (i.e. data fetch address) is set to illegal address
-    ROUNDTUITAL(String),                      // Something is not implemented
+    PSAL(u32, String),                   // Program counter set to illegal address
+    OCSAL(Instruction, String),          // Illegal instruction was read into N register
+    QSAL(Instruction, BadMemOp, String), // Q register (i.e. data fetch address) is set to illegal address
+    ROUNDTUITAL(String),                 // Something is not implemented
     // I/O Alarm in IOS instruction; device broken/maintenance/nonexistent.
     IOSAL {
         unit: Unsigned6Bit,
@@ -28,6 +43,13 @@ pub enum Alarm {
         instr: Option<Instruction>,
         message: String,
     },
+
+    // Loop in deferred addressing (detection of this is not a feature
+    // of the TX-2).
+    DEFERLOOPAL {
+        /// address is some address within the loop.
+        address: Unsigned18Bit,
+    },
 }
 
 impl Display for Alarm {
@@ -35,14 +57,12 @@ impl Display for Alarm {
         use Alarm::*;
         f.write_str("ALARM: ")?;
         match self {
-            QSAL(instruction, address, msg) => {
+            QSAL(instruction, op, msg) => {
                 write!(
-		    f,
-		    "QSAL: during execution of instruction {:?}, memory access to {:>013o} failed: {}",
-		    instruction,
-		    address,
-		    msg,
-		)
+                    f,
+                    "QSAL: during execution of instruction {:?}, {}: {}",
+                    instruction, op, msg,
+                )
             }
             PSAL(address, msg) => {
                 write!(
@@ -89,11 +109,108 @@ impl Display for Alarm {
                     instr, message,
                 )
             }
+            DEFERLOOPAL { address } => {
+                write!(
+                    f,
+                    "DEFERLOOPAL: infinite loop in deferred address at {}",
+                    address,
+                )
+            }
         }
     }
 }
 
 impl Error for Alarm {}
+
+/// The TX-2 can "mask" some alarms, and whether or not this is
+/// happening is controlled by the AlarmUnit.
+#[derive(Debug)]
+pub struct AlarmUnit {
+    mask_psal: bool,
+    mask_ocsal: bool,
+    mask_qsal: bool,
+    mask_iosal: bool,
+    mask_misal: bool,
+    // BUGAL cannot be masked
+    // DEFERLOOPAL cannot be masked.
+}
+
+impl Default for AlarmUnit {
+    fn default() -> AlarmUnit {
+        AlarmUnit {
+            mask_psal: false,
+            mask_ocsal: false,
+            mask_qsal: false,
+            mask_iosal: false,
+            mask_misal: false,
+        }
+    }
+}
+
+impl AlarmUnit {
+    pub fn new() -> AlarmUnit {
+        AlarmUnit::default()
+    }
+
+    fn is_never_masked(alarm_instance: &Alarm) -> bool {
+        matches!(
+            alarm_instance,
+            Alarm::BUGAL { .. } | Alarm::DEFERLOOPAL { .. } | Alarm::ROUNDTUITAL(_)
+        )
+    }
+
+    fn is_masked(&self, alarm_instance: &Alarm) -> bool {
+        let masked = match &alarm_instance {
+            Alarm::PSAL(_, _) => self.mask_psal,
+            Alarm::OCSAL(_, _) => self.mask_ocsal,
+            Alarm::QSAL(_, BadMemOp::Read(_), _) => self.mask_qsal,
+            Alarm::QSAL(_, BadMemOp::Write(_), _) => {
+                // In one of the start-up routines run as a result of
+                // CODABO, memory is wiped by over-writing it with a
+                // repeating pattern, Starting from the top down.
+                // This causes writes to plugboard memory which we
+                // discard and to the unmapped gap below them.  We
+                // have to be able to completer this routine to start
+                // the computer.  So the TX-2 must have either started
+                // up with QSAL masked, or it must ignore writes to
+                // unmapped locations.  I don't know which of these
+                // was the case yet.  For now, we just behave as if
+                // QSAL was masked when the operation is a write.
+                //
+                // TODO: is this correct for writes to un-mapped
+                // memory?
+                true
+            }
+            Alarm::IOSAL { .. } => self.mask_iosal,
+            Alarm::MISAL { .. } => self.mask_misal,
+            Alarm::BUGAL { .. } | Alarm::DEFERLOOPAL { .. } | Alarm::ROUNDTUITAL(_) => {
+                assert!(AlarmUnit::is_never_masked(alarm_instance));
+                return false;
+            }
+        };
+        assert!(!AlarmUnit::is_never_masked(alarm_instance));
+        masked
+    }
+
+    pub fn always_fire(&self, alarm_instance: Alarm) -> Alarm {
+        if AlarmUnit::is_never_masked(&alarm_instance) {
+            alarm_instance
+        } else {
+            panic!(
+                "always_fire was called for alarm {:?} but that alarm can be masked",
+                &alarm_instance,
+            );
+        }
+    }
+
+    pub fn fire_if_not_masked(&self, alarm_instance: Alarm) -> Result<(), Alarm> {
+        if self.is_masked(&alarm_instance) {
+            Ok(())
+        } else {
+            Err(alarm_instance)
+        }
+    }
+}
 
 // Alarm conditions we expect to use in the emulator but
 // which are not in use yet:

--- a/cpu/src/control/mod.rs
+++ b/cpu/src/control/mod.rs
@@ -616,8 +616,8 @@ impl ControlUnit {
         Ok(true) // not in Limbo (i.e. a sequence should run)
     }
 
-    pub fn poll_hardware(&mut self, system_time: &Duration) -> Result<(), Alarm> {
-        let (mut raised_flags, alarm) = self.devices.poll(system_time);
+    pub fn poll_hardware(&mut self, system_time: &Duration) -> Result<Option<Duration>, Alarm> {
+        let (mut raised_flags, alarm, next_poll) = self.devices.poll(system_time);
         // For each newly-raised flag, raise the flag in self.flags.
         event!(
             Level::TRACE,
@@ -654,7 +654,7 @@ impl ControlUnit {
             );
             Err(active)
         } else {
-            Ok(())
+            Ok(next_poll)
         }
     }
 

--- a/cpu/src/control/trap.rs
+++ b/cpu/src/control/trap.rs
@@ -117,7 +117,7 @@ impl Unit for TrapCircuit {
             missed_data: false,
             mode: self.mode,
             // The trap circuit does not need to be polled.
-            poll_before: Duration::from_secs(60),
+            poll_after: Duration::from_secs(60),
             // In truth, I don't know whether the trap unit is an
             // input unit or not.
             is_input_unit: true,

--- a/cpu/src/io/dev_petr.rs
+++ b/cpu/src/io/dev_petr.rs
@@ -269,7 +269,7 @@ impl Unit for Petr {
             inability: self.read_failed,
             missed_data: self.overrun,
             mode: self.mode,
-            poll_before: self.next_poll_time(system_time),
+            poll_after: self.next_poll_time(system_time),
             is_input_unit: true,
         }
     }

--- a/cpu/src/io/dev_petr.rs
+++ b/cpu/src/io/dev_petr.rs
@@ -160,7 +160,7 @@ impl Petr {
     }
 
     fn do_rewind(&mut self) {
-        match self.rewind_line_counter.checked_sub(1 as usize) {
+        match self.rewind_line_counter.checked_sub(1) {
             None | Some(0) => {
                 // We reached - or were already at - the END MARK,
                 // reverse direction.

--- a/cpu/src/io/mod.rs
+++ b/cpu/src/io/mod.rs
@@ -97,7 +97,7 @@ pub struct UnitStatus {
 
     /// Indicates that the unit wishes to be polled for its status
     /// before the indicated (simulated) duration has elapsed.
-    pub poll_before: Duration,
+    pub poll_after: Duration,
 
     /// True for units which are input units.  Some devices (Lincoln
     /// Writers for example) occupy two units, one for read (input)o

--- a/cpu/src/io/mod.rs
+++ b/cpu/src/io/mod.rs
@@ -286,12 +286,9 @@ impl DeviceManager {
             );
             let unit_status = attached.inner.poll(system_time);
             event!(Level::TRACE, "unit status is {:?}", unit_status);
-            match unit_status.change_flag {
-                Some(FlagChange::Raise) => {
-                    event!(Level::TRACE, "unit has raised its flag");
-                    raised_flags |= 1 << u8::from(*devno);
-                }
-                None => (),
+            if let Some(FlagChange::Raise) = unit_status.change_flag {
+                event!(Level::TRACE, "unit has raised its flag");
+                raised_flags |= 1 << u8::from(*devno);
             }
             if alarm.is_none() {
                 // TODO: support masking for alarms (hardware and
@@ -498,5 +495,12 @@ impl DeviceManager {
                 }
             }
         }
+    }
+}
+
+impl Default for DeviceManager {
+    /// We're implementing this mainly to keep clippy happy.
+    fn default() -> DeviceManager {
+        Self::new()
     }
 }

--- a/cpu/src/io/pollq.rs
+++ b/cpu/src/io/pollq.rs
@@ -1,0 +1,117 @@
+use std::cmp::Ordering;
+use std::time::Duration;
+
+use keyed_priority_queue::KeyedPriorityQueue;
+
+use base::prelude::*;
+
+#[derive(Debug)]
+struct ReverseOrdered<T> {
+    inner: T,
+}
+
+impl<T> From<T> for ReverseOrdered<T> {
+    fn from(inner: T) -> ReverseOrdered<T> {
+        ReverseOrdered { inner }
+    }
+}
+
+impl<T: Ord> PartialOrd for ReverseOrdered<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<T: Eq> Eq for ReverseOrdered<T> {}
+
+impl<T: Eq> PartialEq for ReverseOrdered<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.inner == other.inner
+    }
+}
+
+impl<T: Ord> Ord for ReverseOrdered<T> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match self.inner.cmp(&other.inner) {
+            Ordering::Less => Ordering::Greater,
+            Ordering::Equal => Ordering::Equal,
+            Ordering::Greater => Ordering::Less,
+        }
+    }
+}
+
+#[test]
+fn test_reverse_order() {
+    assert_eq!(ReverseOrdered::from(1), ReverseOrdered::from(1));
+    assert_ne!(ReverseOrdered::from(1), ReverseOrdered::from(0));
+    assert!(ReverseOrdered::from(1) < ReverseOrdered::from(0));
+    assert_ne!(ReverseOrdered::from(1), ReverseOrdered::from(0));
+    assert!(!(ReverseOrdered::from(1) > ReverseOrdered::from(0)));
+}
+
+#[derive(Debug)]
+pub struct PollQueue {
+    items: KeyedPriorityQueue<SequenceNumber, ReverseOrdered<Duration>>,
+}
+
+impl PollQueue {
+    pub fn new() -> PollQueue {
+        PollQueue {
+            items: KeyedPriorityQueue::new(),
+        }
+    }
+
+    pub fn peek(&self) -> Option<(&SequenceNumber, &Duration)> {
+        self.items.peek().map(|(k, p)| (k, &p.inner))
+    }
+
+    pub fn pop(&mut self) -> Option<(SequenceNumber, Duration)> {
+        self.items.pop().map(|(k, p)| (k, p.inner))
+    }
+
+    pub fn push(&mut self, key: SequenceNumber, priority: Duration) -> Option<Duration> {
+        match self.items.push(key, ReverseOrdered::from(priority)) {
+            None => None,
+            Some(rd) => Some(rd.inner),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.items.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+}
+
+#[test]
+fn test_pollqueue_empty() {
+    let mut q = PollQueue::new();
+    assert!(q.is_empty());
+    assert_eq!(0, q.len());
+    assert_eq!(q.peek(), None);
+    assert_eq!(q.pop(), None);
+}
+
+#[test]
+fn test_pollqueue_repeat_push() {
+    let mut q = PollQueue::new();
+    assert_eq!(
+        q.push(SequenceNumber::ZERO, Duration::from_micros(200)),
+        None
+    );
+    assert_eq!(
+        q.push(SequenceNumber::ZERO, Duration::from_micros(400)),
+        Some(Duration::from_micros(200))
+    );
+    assert_eq!(
+        q.push(SequenceNumber::ZERO, Duration::from_micros(300)),
+        Some(Duration::from_micros(400))
+    );
+    assert_eq!(
+        q.pop(),
+        Some((SequenceNumber::ZERO, Duration::from_micros(300)))
+    );
+    assert!(q.is_empty());
+}

--- a/cpu/src/memory.rs
+++ b/cpu/src/memory.rs
@@ -333,7 +333,7 @@ impl MemoryUnit {
     ) -> Result<Option<&mut MemoryWord>, MemoryOpFailure> {
         match decode(addr) {
             Some(MemoryDecode::S(offset)) => Ok(Some(&mut self.s_memory[offset])),
-            Some(MemoryDecode::T(offset)) => Ok(Some(&mut self.s_memory[offset])),
+            Some(MemoryDecode::T(offset)) => Ok(Some(&mut self.t_memory[offset])),
             Some(MemoryDecode::U(offset)) => {
                 if let Some(u) = &mut self.u_memory {
                     Ok(Some(&mut u[offset]))

--- a/cpu/src/memory.rs
+++ b/cpu/src/memory.rs
@@ -25,6 +25,8 @@
 ///
 use std::error;
 use std::fmt::{self, Debug, Display, Formatter};
+#[cfg(test)]
+use std::ops::RangeInclusive;
 
 use tracing::{event, Level};
 
@@ -585,10 +587,12 @@ struct VMemory {
     c_register: MemoryWord,
     d_register: MemoryWord,
     e_register: MemoryWord,
-    // TODO: shaft encoders
-    // TODO: external input register
-    // TODO: RTC
-    // TODO: CODABO start points
+
+    unimplemented_shaft_encoder: MemoryWord,
+    unimplemented_external_input_register: MemoryWord,
+    unimplemented_rtc: MemoryWord,
+
+    codabo_start_point: [MemoryWord; 8],
     plugboard: [MemoryWord; 32],
 }
 
@@ -660,7 +664,20 @@ impl VMemory {
             c_register: MemoryWord::default(),
             d_register: MemoryWord::default(),
             e_register: MemoryWord::default(),
+            codabo_start_point: [
+                MemoryWord::default(),
+                MemoryWord::default(),
+                MemoryWord::default(),
+                MemoryWord::default(),
+                MemoryWord::default(),
+                MemoryWord::default(),
+                MemoryWord::default(),
+                MemoryWord::default(),
+            ],
             plugboard: standard_plugboard_internal(),
+            unimplemented_shaft_encoder: MemoryWord::default(),
+            unimplemented_external_input_register: MemoryWord::default(),
+            unimplemented_rtc: MemoryWord::default(),
         }
     }
 
@@ -681,9 +698,38 @@ impl VMemory {
             0o0377606 => Ok(Some(&mut self.c_register)),
             0o0377607 => Ok(Some(&mut self.d_register)),
             0o0377610 => Ok(Some(&mut self.e_register)),
-            // Shaft encoder, External Input Register, Real Time Clock
-            0o0377620 | 0o0377621 | 0o0377630 => todo!(),
-            0o0377710..=0o0377717 => todo!(), // Location of CODABO start points
+            0o0377620 => {
+                // Shaft encoder is not yet implemented.
+                event!(
+                    Level::WARN,
+                    "Reading the shaft encoder is not yet implemented"
+                );
+                Ok(Some(&mut self.unimplemented_shaft_encoder))
+            }
+            0o0377621 => {
+                // Shaft encoder is not yet implemented.
+                event!(
+                    Level::WARN,
+                    "Reading the external input register is not yet implemented"
+                );
+                Ok(Some(&mut self.unimplemented_external_input_register))
+            }
+            0o0377630 => {
+                event!(
+                    Level::WARN,
+                    "Reading the real-time clock is not yet implemented"
+                );
+                Ok(Some(&mut self.unimplemented_rtc))
+            }
+            0o0377710 => Ok(Some(&mut self.codabo_start_point[0])), // CODABO Reset0
+            0o0377711 => Ok(Some(&mut self.codabo_start_point[1])), // CODABO Reset1
+            0o0377712 => Ok(Some(&mut self.codabo_start_point[2])), // CODABO Reset2
+            0o0377713 => Ok(Some(&mut self.codabo_start_point[3])), // CODABO Reset3
+            0o0377714 => Ok(Some(&mut self.codabo_start_point[4])), // CODABO Reset4
+            0o0377715 => Ok(Some(&mut self.codabo_start_point[5])), // CODABO Reset5
+            0o0377716 => Ok(Some(&mut self.codabo_start_point[6])), // CODABO Reset6
+            0o0377717 => Ok(Some(&mut self.codabo_start_point[7])), // CODABO Reset7
+
             addr @ 0o0377740..=0o0377777 => {
                 if let Ok(offset) = TryInto::<usize>::try_into(addr - 0o0377740) {
                     Ok(Some(&mut self.plugboard[offset]))
@@ -696,5 +742,40 @@ impl VMemory {
             }
             _ => Err(MemoryOpFailure::NotMapped),
         }
+    }
+}
+
+#[cfg(test)]
+fn all_physical_memory_addresses() -> RangeInclusive<u32> {
+    let start = 0_u32;
+    let end: u32 = u32::from(Unsigned18Bit::MAX) >> 1;
+    start..=end
+}
+
+#[test]
+fn test_write_all_mem() {
+    let mut mem = MemoryUnit::new(&MemoryConfiguration {
+        with_u_memory: false,
+    });
+    for a in all_physical_memory_addresses() {
+        let addr: Address = Address::try_from(a).unwrap();
+        // The point of this test is to verify that we con't have any
+        // todo!()s in reachable code paths.
+        drop(mem.access(&MemoryAccess::Write, &addr));
+        // TODO: make this test fail if there is a ROUNDTUITAL.
+    }
+}
+
+#[test]
+fn test_read_all_mem() {
+    let mut mem = MemoryUnit::new(&MemoryConfiguration {
+        with_u_memory: false,
+    });
+    for a in all_physical_memory_addresses() {
+        let addr: Address = Address::try_from(a).unwrap();
+        // The point of this test is to verify that we con't have any
+        // todo!()s in reachable code paths.
+        drop(mem.access(&MemoryAccess::Read, &addr))
+        // TODO: make this test fail if there is a ROUNDTUITAL.
     }
 }

--- a/cpu/src/memory.rs
+++ b/cpu/src/memory.rs
@@ -687,9 +687,10 @@ impl VMemory {
         addr: &Address,
     ) -> Result<Option<&mut MemoryWord>, MemoryOpFailure> {
         if access_type == &MemoryAccess::Write {
-            // There appear to be some instructions which special-case
-            // attempts to write to arithmetic unit registers, so we
-            // may need a more sophisticated approach here.
+            // TODO: there appear to be some instructions which
+            // special-case attempts to write to arithmetic unit
+            // registers, so we may need a more sophisticated approach
+            // here.
             return Ok(None);
         }
         match u32::from(addr) {


### PR DESCRIPTION
Several changes got merged into my main branch.

- **IO**: the basic idea here is that we don't poll hardware devices before the next time at which they say something interesting is going to happen.  We'll need to adjust this a bit when we introduce output devices, but we don't have any of those yet.
- **Alarm masking**: the TX-2 allows alarms to be masked in hardware, and this change implements that (alarms can also be masked in software, but this is not yet implemented).
- **Deferred addressing**: during a deferred addressing cycle, the index (j) bits are now correctly used.  This is an important fix, because this is poorly documented in the available documentation (see references in the code).

